### PR TITLE
docs(openspec): add CSS variable naming standard proposals

### DIFF
--- a/openspec/changes/establish-css-variable-naming-standard/design.md
+++ b/openspec/changes/establish-css-variable-naming-standard/design.md
@@ -1,0 +1,561 @@
+# CSS Variable Naming Convention Design
+
+## Context
+
+The @fpkit/acss library has grown organically to include 18 components with over 200 CSS custom properties. An audit revealed significant inconsistencies:
+
+### Current State Analysis
+
+**Components with Excellent Patterns:**
+- **Alert**: `--alert-error-bg`, `--alert-error-border`, `--alert-error-color` (consistent variant structure)
+- **List**: `--list-item-padding`, `--list-marker-color` (clear element scoping)
+- **Link**: `--link-focus-outline`, `--link-hover-color` (predictable state variables)
+
+**Components with Problematic Patterns:**
+- **Button**: `--btn-fs`, `--btn-rds`, `--btn-cl`, `--btn-dsp`, `--btn-px`, `--btn-py` (heavy abbreviations)
+- **Nav**: `--nav-dsp`, `--nav-hov-bg`, `--nav-mb` (inconsistent abbreviations)
+- **Card**: `--card-p` (should be `--card-padding`)
+- **Form**: `--input-px`, `--input-py`, `--input-w` (mixed abbreviation styles)
+
+**Key Findings:**
+- 60% of components use abbreviated property names inconsistently
+- Width/height alternate between `--w`/`--h` and `--width`/`--height`
+- Padding uses `--p`, `--px`, `--py`, `--padding`, and `--padding-inline` interchangeably
+- No consistent pattern for variants (some use `--component-variant-property`, others use `--component-property-variant`)
+
+### Constraints
+
+1. **Balance brevity with clarity** - Variables shouldn't be overly verbose, but must be understandable
+2. **Support IDE autocomplete** - Typing `--btn-` should reveal related variables in a logical order
+3. **Maintain CSS best practices** - Follow established CSS custom property conventions
+4. **Enable easy migration** - Pattern must be simple enough for find-and-replace operations
+5. **Future-proof** - Must accommodate new components and property types
+
+### Stakeholders
+
+- **Library Users**: Need predictable, discoverable customization variables
+- **Component Developers**: Need clear guidelines for adding/modifying components
+- **Maintainers**: Need consistency for easier code reviews and refactoring
+- **Documentation Writers**: Need standardized patterns to document effectively
+
+## Goals / Non-Goals
+
+### Goals
+
+1. **Establish a single, authoritative naming pattern** for all CSS custom properties
+2. **Define approved abbreviations** that balance brevity and clarity
+3. **Organize variables** by component, element, variant, and state in a predictable hierarchy
+4. **Enable better IDE tooling** through consistent prefixes and structure
+5. **Reduce cognitive load** for users learning the library
+6. **Provide clear migration paths** from current inconsistent names
+
+### Non-Goals
+
+1. **Implementing the changes** - This proposal documents the standard only
+2. **Refactoring all components immediately** - Implementation will be phased
+3. **Removing all abbreviations** - Some well-known abbreviations (bg, fs) are acceptable
+4. **Breaking compatibility** in this proposal - No code changes yet
+5. **Standardizing non-CSS aspects** - Focus only on CSS variable naming, not class names or other conventions
+
+## Decisions
+
+### Decision 1: Variable Pattern Structure
+
+**Chosen Pattern:**
+```
+--{component}-{element}-{variant}-{property}-{modifier}
+```
+
+**Examples:**
+```scss
+--btn-bg                        // Base property
+--btn-primary-bg                // Variant property
+--btn-hover-bg                  // State property
+--card-header-padding           // Element-specific property
+--alert-error-border            // Variant with specific property
+--btn-focus-outline-offset      // State with modified property
+```
+
+**Hierarchy Order:**
+1. **Component** (required) - `btn`, `alert`, `card`, `nav`, etc.
+2. **Element** (optional) - `header`, `footer`, `title`, `content`
+3. **Variant** (optional) - `primary`, `secondary`, `error`, `success`
+4. **Property** (required) - `bg`, `color`, `padding`, `border`
+5. **Modifier** (optional) - `offset`, `width`, `style`, `radius`
+
+**Rationale:**
+
+| Alternative Considered | Why Rejected |
+|---|---|
+| `--{property}-{component}-{variant}` (property-first) | Breaks IDE autocomplete by component. Users want to type `--btn-` and see all button properties |
+| `--{component}-{property}-{variant}` (variant last) | Less intuitive for discovering variants. Typing `--btn-primary-` shows all primary button properties, which is the desired UX |
+| Flat structure with no hierarchy | Doesn't scale as components get more complex (e.g., card headers, alert icons) |
+
+**IDE Autocomplete Benefits:**
+- Type `--btn-` → See all button properties
+- Type `--btn-primary-` → See all primary variant properties
+- Type `--btn-hover-` → See all hover state properties
+- Type `--card-header-` → See all card header properties
+
+### Decision 2: Approved Abbreviations
+
+**Abbreviated Terms (Widely Recognized):**
+
+| Abbreviation | Full Name | Rationale |
+|---|---|---|
+| `bg` | background / background-color | Universal CSS convention, extremely common |
+| `fs` | font-size | Well-established in typography systems |
+| `fw` | font-weight | Common in typography systems |
+| `radius` | border-radius | Short enough, clearer than `bdr-rds` |
+| `gap` | gap | Already one word, no abbreviation needed |
+
+**Full Words Required:**
+
+| Property | ❌ Don't Use | ✅ Use | Rationale |
+|---|---|---|---|
+| padding | `p`, `px`, `py` | `padding`, `padding-inline`, `padding-block` | Logical properties are new, need clarity |
+| margin | `m`, `mx`, `my`, `mb` | `margin`, `margin-inline`, `margin-block` | Logical properties are new, need clarity |
+| color | `cl`, `c` | `color` | Too ambiguous when abbreviated |
+| border | `bdr`, `br` | `border` | Avoid confusion with `border-radius` |
+| display | `dsp`, `d` | `display` | Not universally recognized abbreviation |
+| width | `w` | `width` | Single-letter abbreviations reduce clarity |
+| height | `h` | `height` | Single-letter abbreviations reduce clarity |
+| min-width | `min-w` | `min-width` | Consistency with `width` |
+| max-height | `max-h` | `max-height` | Consistency with `height` |
+
+**Rationale for Selective Abbreviation:**
+- Properties abbreviated for **decades** in CSS communities (like `bg`) are safe
+- **Logical properties** (`padding-inline`, `margin-block`) are too new to abbreviate without confusion
+- **Single-letter** abbreviations (`w`, `h`, `p`) are ambiguous and harm readability
+- **Multi-letter** abbreviations (`dsp`, `cl`) aren't universally recognized
+
+**Alternatives Considered:**
+1. **Full spelling everything** - Rejected as overly verbose (`--button-background-color`)
+2. **Abbreviate everything** - Rejected as cryptic (`--btn-bdr-rds`, `--btn-cl`)
+3. **User-configurable** - Rejected as it breaks consistency
+
+### Decision 3: Variant Organization
+
+**Chosen Pattern:** `--{component}-{variant}-{property}`
+
+```scss
+// Semantic variants (UI states)
+--alert-error-bg
+--alert-error-border
+--alert-error-color
+
+--alert-warning-bg
+--alert-warning-border
+
+// Style variants (visual themes)
+--btn-primary-bg
+--btn-primary-color
+
+--btn-secondary-bg
+--btn-secondary-border
+```
+
+**Why variant comes before property:**
+- **Discoverability**: Typing `--alert-error-` shows all error-related properties
+- **Grouping**: Related variant properties appear together in autocomplete
+- **Matches user mental model**: "I want to change the error alert" → `--alert-error-*`
+
+**Alternative Considered:** `--{component}-{property}-{variant}`
+```scss
+// Example: --alert-bg-error
+--alert-bg-error
+--alert-bg-warning
+--alert-border-error
+--alert-border-warning
+```
+
+**Why Rejected:**
+- Groups by property type (all backgrounds together) rather than by variant
+- Less intuitive for theming ("change error styles" vs "change all backgrounds")
+- Doesn't match how users think about customization
+
+### Decision 4: State Variables
+
+**Pattern:** `--{component}-{state}-{property}`
+
+```scss
+--btn-hover-bg
+--btn-hover-transform
+--btn-hover-filter
+
+--btn-focus-outline
+--btn-focus-outline-offset
+--btn-focus-color
+
+--btn-disabled-opacity
+--btn-disabled-cursor
+
+--link-visited-color
+--link-active-color
+```
+
+**Common States:**
+- `hover` - Mouse hover state
+- `focus` - Keyboard focus state
+- `active` - Active/pressed state
+- `disabled` - Disabled state
+- `visited` - Visited link state (links only)
+- `checked` - Checked state (checkboxes, radios)
+
+**Rationale:**
+- States follow the same pattern as variants for consistency
+- Easy to discover all hover properties: `--btn-hover-*`
+- Aligns with pseudo-class naming in CSS (`:hover`, `:focus`, `:disabled`)
+
+### Decision 5: Element-Specific Variables
+
+**Pattern:** `--{component}-{element}-{property}`
+
+```scss
+// Card component with multiple elements
+--card-padding
+--card-bg
+
+--card-header-padding
+--card-header-bg
+--card-header-border-bottom
+
+--card-body-padding
+--card-body-gap
+
+--card-footer-padding
+--card-footer-bg
+```
+
+**When to use element scoping:**
+- Component has distinct visual sections (header, footer, body)
+- Each section can be styled independently
+- Sub-elements have unique properties (e.g., card header has border-bottom, body doesn't)
+
+**When NOT to use element scoping:**
+- Simple components with no visual hierarchy (Badge, Tag)
+- Elements that are purely structural (don't need custom styling)
+
+## Examples
+
+### Example 1: Button Component (Before → After)
+
+**Current (Inconsistent):**
+```scss
+--btn-xs: 0.6875rem;
+--btn-sm: 0.8125rem;
+--btn-md: 0.9375rem;
+--btn-lg: 1.125rem;
+
+--btn-fs: var(--btn-md);          // ❌ Abbreviation
+--btn-px: calc(var(--btn-fs) * 1.5);  // ❌ px means padding-inline?
+--btn-py: calc(var(--btn-fs) * 0.5);  // ❌ py means padding-block?
+--btn-rds: 0.375rem;              // ❌ radius abbreviation
+--btn-cl: currentColor;           // ❌ color abbreviation
+--btn-dsp: inline-flex;           // ❌ display abbreviation
+--btn-bdr: 1px solid;             // ❌ border abbreviation
+--btn-hov-bg: ..;                 // ❌ Inconsistent state name
+```
+
+**Proposed (Consistent):**
+```scss
+// Size tokens
+--btn-size-xs: 0.6875rem;
+--btn-size-sm: 0.8125rem;
+--btn-size-md: 0.9375rem;
+--btn-size-lg: 1.125rem;
+
+// Base properties
+--btn-fs: var(--btn-size-md);        // ✅ fs is approved abbreviation
+--btn-padding-inline: calc(var(--btn-fs) * 1.5);  // ✅ Clear logical property
+--btn-padding-block: calc(var(--btn-fs) * 0.5);   // ✅ Clear logical property
+--btn-radius: 0.375rem;              // ✅ radius is approved
+--btn-color: currentColor;           // ✅ Full word
+--btn-display: inline-flex;          // ✅ Full word
+--btn-border: 1px solid;             // ✅ Full word
+
+// Variant properties
+--btn-primary-bg: #0066cc;           // ✅ Variant pattern
+--btn-primary-color: white;
+
+--btn-secondary-bg: transparent;
+--btn-secondary-border: 1px solid currentColor;
+
+// State properties
+--btn-hover-bg: ..;                  // ✅ Consistent state name
+--btn-hover-transform: translateY(-1px);
+--btn-focus-outline: 2px solid currentColor;
+--btn-disabled-opacity: 0.6;
+```
+
+**Improvements:**
+- ✅ Clear distinction between size tokens (`--btn-size-*`) and applied size
+- ✅ Logical properties spelled out (`padding-inline`, not `px`)
+- ✅ Consistent abbreviations (only approved ones: `fs`, `bg`)
+- ✅ Discoverable variants (`--btn-primary-*`)
+- ✅ Clear state variables (`--btn-hover-*`, `--btn-focus-*`)
+
+### Example 2: Alert Component (Already Good!)
+
+**Current (Keep This Pattern):**
+```scss
+// Base properties
+--alert-padding: 1rem;
+--alert-margin-block-end: 1rem;
+--alert-border-radius: 0.375rem;
+--alert-gap: 0.75rem;
+--alert-border: 1px solid;
+--alert-bg: #f0f0f0;
+--alert-color: inherit;
+
+// Semantic variants
+--alert-success-bg: #d4edda;
+--alert-success-border: #c3e6cb;
+--alert-success-color: #155724;
+
+--alert-error-bg: #f8d7da;
+--alert-error-border: #f5c6cb;
+--alert-error-color: #721c24;
+
+--alert-warning-bg: #fff3cd;
+--alert-warning-border: #ffeeba;
+--alert-warning-color: #856404;
+
+--alert-info-bg: #d1ecf1;
+--alert-info-border: #bee5eb;
+--alert-info-color: #0c5460;
+```
+
+**✅ This is already excellent! Use as reference pattern.**
+
+**Why it works:**
+- Full words for clarity (`padding`, `margin-block-end`, `border-radius`)
+- Consistent variant structure (`--alert-{variant}-{property}`)
+- Logical property usage (`margin-block-end`)
+- Semantic variant names (`success`, `error`, `warning`, `info`)
+
+### Example 3: Card Component (Before → After)
+
+**Current:**
+```scss
+--card-p: 1rem;                  // ❌ Abbreviated padding
+--card-bg: white;                // ✅ Good
+--card-radius: 0.5rem;           // ✅ Good
+--card-position: relative;       // ✅ Good
+--card-display: flex;            // ✅ Good
+--card-direction: column;        // ✅ Good
+--card-gap: 1rem;                // ✅ Good
+--card-align: stretch;           // ✅ Good
+```
+
+**Proposed:**
+```scss
+// Base card properties
+--card-padding: 1rem;            // ✅ Full word
+--card-bg: white;
+--card-radius: 0.5rem;
+--card-display: flex;
+--card-direction: column;
+--card-gap: 1rem;
+
+// Element-specific (if card has header/footer)
+--card-header-padding: 1rem 1.5rem;
+--card-header-border-bottom: 1px solid #ddd;
+
+--card-body-padding: 1.5rem;
+
+--card-footer-padding: 1rem 1.5rem;
+--card-footer-bg: #f9f9f9;
+```
+
+**Improvements:**
+- ✅ `--card-p` → `--card-padding` (clear)
+- ✅ Added element scoping for complex card layouts
+- ✅ Maintains consistency with other components
+
+### Example 4: Form/Input Component (Before → After)
+
+**Current:**
+```scss
+--input-px: 0.75rem;             // ❌ Abbreviation
+--input-py: 0.5rem;              // ❌ Abbreviation
+--input-fs: 1rem;                // ✅ fs is approved
+--input-w: 100%;                 // ❌ Abbreviation
+--input-border-color: #ccc;      // ✅ Good
+--input-bg: white;               // ✅ Good
+```
+
+**Proposed:**
+```scss
+--input-padding-inline: 0.75rem; // ✅ Clear logical property
+--input-padding-block: 0.5rem;   // ✅ Clear logical property
+--input-fs: 1rem;                // ✅ Approved abbreviation
+--input-width: 100%;             // ✅ Full word
+--input-border-color: #ccc;
+--input-bg: white;
+--input-radius: 0.25rem;
+
+// State variables
+--input-focus-outline: 2px solid blue;
+--input-focus-outline-offset: 2px;
+--input-disabled-bg: #e9ecef;
+--input-disabled-opacity: 0.6;
+```
+
+## Risks / Trade-offs
+
+### Risk 1: Breaking Changes in Implementation
+
+**Risk:** When implementation proposals refactor variables, user stylesheets will break.
+
+**Trade-off:**
+- **Pro**: Clean, consistent naming across the library
+- **Con**: Major version bump required; users must migrate
+
+**Mitigation:**
+- Provide comprehensive migration guide with before/after tables
+- Offer find-and-replace regex patterns
+- Publish beta versions for testing
+- Document all changes in CHANGELOG with migration examples
+
+### Risk 2: Longer Variable Names
+
+**Risk:** Full words increase variable name length.
+
+**Trade-off:**
+- **Pro**: Improved clarity and discoverability
+- **Con**: Slightly more typing (e.g., `--btn-padding-inline` vs `--btn-px`)
+
+**Mitigation:**
+- IDE autocomplete reduces typing burden
+- Better DX outweighs extra characters
+- Consistency reduces cognitive load
+
+**Analysis:** Most professional design systems use full words (Material Design, Carbon, Polaris). This is an industry standard.
+
+### Risk 3: Not All Edge Cases Covered
+
+**Risk:** Some components may have unique requirements not covered by the standard.
+
+**Mitigation:**
+- Include escape hatch clause: "Deviate when necessary, document why"
+- Gather feedback during implementation phases
+- Update standard based on real-world usage
+
+### Risk 4: Adoption Resistance
+
+**Risk:** Developers may resist changing familiar variable names.
+
+**Mitigation:**
+- Lead by example in high-impact component refactoring
+- Integrate standard into code review process
+- Update CLAUDE.md and contribution guidelines
+- Provide clear rationale for each decision
+
+## Migration Plan
+
+### Phase 1: Documentation (This Proposal)
+1. Publish CSS Variable Reference Guide
+2. Update CLAUDE.md with naming standard
+3. Create migration guide template
+4. Get team approval
+
+### Phase 2: High-Impact Components
+- Refactor Button, Form, Card (separate proposal)
+- Gather user feedback
+- Refine standard if needed
+
+### Phase 3: Remaining Components
+- Apply learnings from Phase 2
+- Refactor all other components
+- Update all documentation
+
+### Phase 4: Tooling (Future)
+- Build variable discovery tool
+- Create automated migration scripts
+- Generate documentation from SCSS files
+
+## Open Questions
+
+### Q1: Should we enforce this in linting?
+
+**Options:**
+A. Manual code review only
+B. Create custom ESLint/Stylelint rules to enforce naming
+C. Add pre-commit hooks that check variable names
+
+**Recommendation:** Start with (A) manual review. Add linting in Phase 3 after the pattern is proven.
+
+### Q2: How do we handle third-party design tokens?
+
+**Scenario:** If the library integrates with an external design system (e.g., design tokens from Figma).
+
+**Options:**
+A. Prefix external tokens differently (`--token-*` vs `--component-*`)
+B. Map external tokens to our naming convention
+C. Allow external tokens to bypass the standard
+
+**Recommendation:** Defer until needed. Current library doesn't integrate external systems.
+
+### Q3: Should component-level class names follow similar patterns?
+
+**Example:** If variables are `--btn-primary-bg`, should classes be `.btn-primary`?
+
+**Decision:** Out of scope for this proposal. CSS variable naming is orthogonal to class naming.
+
+### Q4: How do we handle responsive/breakpoint-specific variables?
+
+**Example:**
+```scss
+--btn-fs-mobile: 0.875rem;
+--btn-fs-tablet: 1rem;
+--btn-fs-desktop: 1.125rem;
+```
+
+**Recommendation:** Defer to implementation. Most components use CSS clamp() or media queries within variables rather than breakpoint-suffixed variables.
+
+## Success Metrics
+
+This proposal succeeds if:
+
+1. **Documentation is comprehensive** - Covers all pattern variations with examples
+2. **Team approves the standard** - No major objections, consensus on approach
+3. **Implementation proposals reference this** - Used as authoritative source
+4. **Users find it intuitive** - Positive feedback during beta testing
+5. **New components follow the pattern** - Standard is adopted for future work
+
+## References
+
+### Industry Examples
+
+**Material Design (Google):**
+```css
+--mdc-theme-primary
+--mdc-theme-on-primary
+--mdc-typography-body1-font-size
+```
+Pattern: `--{system}-{category}-{property}`
+
+**Carbon Design System (IBM):**
+```css
+--cds-button-primary
+--cds-button-secondary
+--cds-text-01
+```
+Pattern: `--{prefix}-{component}-{variant}`
+
+**Polaris (Shopify):**
+```css
+--p-button-font-size
+--p-button-padding
+--p-color-bg-surface
+```
+Pattern: `--{prefix}-{component/category}-{property}`
+
+**Takeaway:** All major design systems use **full words** and **consistent hierarchical patterns**. Our approach aligns with industry best practices.
+
+### Related Reading
+
+- [CSS Custom Properties Best Practices (MDN)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
+- [Design Tokens W3C Community Group](https://design-tokens.github.io/community-group/)
+- [Design Systems Naming Conventions](https://medium.com/eightshapes-llc/naming-tokens-in-design-systems-9e86c7444676)

--- a/openspec/changes/establish-css-variable-naming-standard/proposal.md
+++ b/openspec/changes/establish-css-variable-naming-standard/proposal.md
@@ -1,0 +1,199 @@
+# CSS Variable Naming Standard Proposal
+
+## Why
+
+The @fpkit/acss component library currently uses **inconsistent CSS custom property naming** across its 18 components with 200+ variables. This creates significant challenges for users who want to customize component styles:
+
+**Current Problems:**
+- **Unpredictable patterns**: Some components use `--btn-px` while others use `--dialog-padding-inline`
+- **Heavy abbreviations**: Variables like `--btn-fs`, `--btn-rds`, `--btn-cl`, `--btn-dsp` require users to decipher meanings
+- **Poor IDE experience**: Inconsistent naming breaks autocomplete workflows (typing `--btn-` doesn't reveal all button properties consistently)
+- **Difficult customization**: Users must inspect each component's SCSS file to discover variable names
+- **Maintenance burden**: No standard to follow when adding new components or refactoring existing ones
+
+**Analysis Findings:**
+- **18 components analyzed** with varying naming quality
+- **Excellent patterns exist** (Alert with `--alert-error-bg`, List with `--list-item-padding`)
+- **Problematic patterns** (Button with `--btn-fs`, `--btn-rds`, `--btn-cl`)
+- **Inconsistent abbreviations** across similar properties (padding: `--card-p` vs `--dialog-padding`)
+
+Without a standard, every new component adds to the inconsistency, making the library harder to learn and use.
+
+## What Changes
+
+This proposal establishes a **comprehensive CSS variable naming convention** that will serve as the foundation for all current and future components. This is a **documentation-only change** with no code modifications.
+
+### Naming Convention Standard
+
+**Core Pattern:**
+```
+--{component}-{element}-{variant}-{property}-{modifier}
+```
+
+**Examples:**
+- `--btn-bg` - Component base property
+- `--btn-primary-bg` - Variant-specific property
+- `--btn-hover-bg` - State-specific property
+- `--btn-focus-outline` - State with specific property
+- `--card-header-padding` - Element-specific property
+
+### Approved Abbreviations
+
+To balance brevity with clarity, we'll standardize on these abbreviations:
+
+**Abbreviated (widely recognized):**
+- `bg` = background / background-color
+- `fs` = font-size
+- `fw` = font-weight
+- `radius` = border-radius
+- `gap` = gap
+
+**Full Words (for clarity):**
+- `padding` (not `p`, `px`, `py`)
+- `padding-inline` (not `px`)
+- `padding-block` (not `py`)
+- `margin` (not `m`, `mx`, `my`)
+- `margin-inline` (not `mx`)
+- `margin-block` (not `my`)
+- `color` (not `cl`)
+- `border` (not `bdr`)
+- `display` (not `dsp`)
+- `width` (not `w`)
+- `height` (not `h`)
+
+**Rationale:** Common CSS properties like `background` and `font-size` can be abbreviated because they're universally recognized. Logical properties (`padding-inline`, `margin-block`) should be spelled out since they're relatively new and less familiar.
+
+### Variant Organization
+
+**Pattern:** `--{component}-{variant}-{property}`
+
+```scss
+// Semantic variants (error, success, warning, info)
+--alert-error-bg
+--alert-error-border
+--alert-error-color
+
+// Style variants (primary, secondary, tertiary)
+--btn-primary-bg
+--btn-secondary-bg
+
+// Size variants (handled via size tokens)
+--btn-size-xs
+--btn-size-sm
+--btn-size-md
+--btn-size-lg
+```
+
+### State Variables
+
+**Pattern:** `--{component}-{state}-{property}`
+
+```scss
+--btn-hover-bg
+--btn-hover-transform
+--btn-focus-outline
+--btn-focus-color
+--btn-disabled-opacity
+--link-visited-color
+```
+
+### Documentation Deliverables
+
+1. **CSS Variable Reference Guide** (`docs/css-variables.md`)
+   - Complete pattern explanation with examples
+   - Approved abbreviations list
+   - Component-by-component variable reference
+   - Customization examples
+
+2. **Migration Guide Template** (`MIGRATION-template.md`)
+   - Before/after naming examples
+   - Find-and-replace patterns
+   - Component-specific migration tables
+   - Storybook customization examples
+
+3. **Contribution Guidelines** (update to `CLAUDE.md`)
+   - Add CSS variable naming rules
+   - Include examples for new components
+   - Reference standard in component development workflow
+
+## Impact
+
+### Affected Specs
+- **NEW:** `specs/design-system-theming/spec.md` - Design System Theming and CSS Variables
+
+### Affected Code
+**None** - This proposal is documentation-only and establishes the standard without implementing changes.
+
+### Breaking Changes
+**None** - No code changes, no API changes, no breaking changes.
+
+### Enables Future Work
+
+This proposal is a **prerequisite** for:
+- `refactor-core-component-css-variables` - High-impact component refactoring
+- `refactor-remaining-css-variables` - Complete library refactoring
+- All future component additions (provides clear standard to follow)
+
+### Benefits
+
+**For Users:**
+- ✅ Predictable variable names across all components
+- ✅ Better IDE autocomplete experience
+- ✅ Easier to discover customization options
+- ✅ Clearer documentation with consistent examples
+- ✅ Reduced learning curve for library adoption
+
+**For Maintainers:**
+- ✅ Clear standard for adding new components
+- ✅ Consistent refactoring targets
+- ✅ Easier code reviews (standard compliance checking)
+- ✅ Improved long-term maintainability
+
+**For the Library:**
+- ✅ Professional, polished developer experience
+- ✅ Competitive with other design systems
+- ✅ Foundation for automated tooling (variable discovery, documentation generation)
+
+### Timeline
+
+- **Week 1**: Draft documentation and examples
+- **Week 2**: Review and finalize standard
+- **Week 3**: Integrate into project documentation and contribution guidelines
+
+**Total**: 2-3 weeks for documentation completion
+
+### Dependencies
+
+**Required Before Implementation:**
+- None - This is a foundational proposal
+
+**Blocks:**
+- Implementation proposals that refactor CSS variables (should wait for approval)
+
+### Risks and Mitigation
+
+**Risk 1: Standard too rigid**
+- *Mitigation*: Include escape hatches for legitimate exceptions; document when to deviate
+
+**Risk 2: Team doesn't adopt standard**
+- *Mitigation*: Integrate into CLAUDE.md and PR review checklist; lead by example in refactoring work
+
+**Risk 3: Conflicts with existing patterns**
+- *Mitigation*: Document migration strategy; allow gradual adoption
+
+## Success Criteria
+
+- [ ] CSS Variable Reference Guide published with complete pattern documentation
+- [ ] Migration guide template ready for implementation proposals
+- [ ] Contribution guidelines updated with naming standard
+- [ ] Standard reviewed and approved by maintainers
+- [ ] Examples demonstrate all pattern variations
+- [ ] At least 5 real-world customization scenarios documented
+
+## Next Steps
+
+After approval:
+1. Create detailed CSS Variable Reference Guide
+2. Update CLAUDE.md with naming standard
+3. Create migration guide template
+4. Begin implementation proposal for high-impact components (Button, Form, Card)

--- a/openspec/changes/establish-css-variable-naming-standard/specs/design-system-theming/spec.md
+++ b/openspec/changes/establish-css-variable-naming-standard/specs/design-system-theming/spec.md
@@ -1,0 +1,213 @@
+# Design System Theming Specification
+
+## ADDED Requirements
+
+### Requirement: CSS Variable Naming Convention
+
+All CSS custom properties in the @fpkit/acss library SHALL follow a consistent, hierarchical naming pattern to enable predictable customization and better developer experience.
+
+The naming pattern SHALL be: `--{component}-{element}-{variant}-{property}-{modifier}` where:
+- **component** (required): Component name in kebab-case (`btn`, `alert`, `card`, `nav`, etc.)
+- **element** (optional): Sub-element name for complex components (`header`, `footer`, `body`, `title`)
+- **variant** (optional): Visual or semantic variant (`primary`, `secondary`, `error`, `success`, `warning`)
+- **property** (required): CSS property name using approved abbreviations or full words
+- **modifier** (optional): Property modifier for compound properties (`offset`, `width`, `style`)
+
+Components SHALL prefix all custom properties with their component name to prevent naming collisions and enable IDE autocomplete by component.
+
+#### Scenario: Basic component property variable
+
+- **WHEN** a component defines a background color variable
+- **THEN** the variable SHALL be named `--{component}-bg`
+- **AND** the variable SHALL be scoped to the component
+- **EXAMPLE**: `--btn-bg`, `--card-bg`, `--alert-bg`
+
+#### Scenario: Variant-specific property variable
+
+- **WHEN** a component has multiple style variants with different colors
+- **THEN** the variable SHALL be named `--{component}-{variant}-{property}`
+- **AND** the variant name SHALL come before the property name
+- **EXAMPLE**: `--btn-primary-bg`, `--alert-error-border`, `--btn-secondary-color`
+
+#### Scenario: State-specific property variable
+
+- **WHEN** a component has interactive states with custom styling
+- **THEN** the variable SHALL be named `--{component}-{state}-{property}`
+- **AND** the state name SHALL follow CSS pseudo-class names (hover, focus, active, disabled)
+- **EXAMPLE**: `--btn-hover-bg`, `--link-focus-outline`, `--btn-disabled-opacity`
+
+#### Scenario: Element-specific property variable
+
+- **WHEN** a complex component has distinct visual sections
+- **THEN** the variable SHALL be named `--{component}-{element}-{property}`
+- **AND** the element name SHALL describe the sub-component (header, footer, body)
+- **EXAMPLE**: `--card-header-padding`, `--dialog-footer-bg`, `--card-body-gap`
+
+#### Scenario: Compound property variable
+
+- **WHEN** a CSS property has multiple sub-properties
+- **THEN** the variable SHALL include a modifier as the final segment
+- **EXAMPLE**: `--btn-focus-outline-offset`, `--alert-border-width`, `--card-border-radius`
+
+### Requirement: Approved Abbreviations
+
+CSS custom properties SHALL use approved abbreviations for common CSS properties to balance brevity with clarity. The library SHALL maintain a definitive list of approved abbreviations and require full words for all other properties.
+
+**Approved abbreviations:**
+- `bg` for background or background-color
+- `fs` for font-size
+- `fw` for font-weight
+- `radius` for border-radius (preferred over `border-radius`)
+- `gap` for gap (no abbreviation needed, already short)
+
+**Required full words:**
+- `padding`, `padding-inline`, `padding-block` (NOT `p`, `px`, `py`)
+- `margin`, `margin-inline`, `margin-block` (NOT `m`, `mx`, `my`)
+- `color` (NOT `cl`, `c`)
+- `border` (NOT `bdr`, `br`)
+- `display` (NOT `dsp`, `d`)
+- `width`, `min-width`, `max-width` (NOT `w`, `min-w`, `max-w`)
+- `height`, `min-height`, `max-height` (NOT `h`, `min-h`, `max-h`)
+
+The abbreviation list SHALL be documented in the CSS Variable Reference Guide and SHALL be updated through the OpenSpec proposal process if new abbreviations are needed.
+
+#### Scenario: Using approved abbreviation
+
+- **WHEN** a component defines a background color variable
+- **THEN** the variable SHALL use `bg` abbreviation
+- **AND** the full name SHALL be documented in comments or documentation
+- **EXAMPLE**: `--btn-bg` (background), `--alert-error-bg` (background-color)
+
+#### Scenario: Using full word for logical property
+
+- **WHEN** a component defines padding using logical properties
+- **THEN** the variable SHALL use the full logical property name
+- **AND** the variable SHALL NOT use abbreviations like `px` or `py`
+- **EXAMPLE**: `--btn-padding-inline` (NOT `--btn-px`), `--card-padding-block` (NOT `--card-py`)
+
+#### Scenario: Using full word for clarity
+
+- **WHEN** a component defines width, height, color, border, or display
+- **THEN** the variable SHALL use the full property name
+- **AND** single-letter abbreviations SHALL NOT be used
+- **EXAMPLE**: `--input-width` (NOT `--input-w`), `--nav-height` (NOT `--nav-h`), `--btn-color` (NOT `--btn-cl`)
+
+#### Scenario: Rejecting non-approved abbreviation
+
+- **WHEN** a developer attempts to use a non-approved abbreviation
+- **THEN** code review SHALL request the full property name
+- **AND** the variable SHALL be renamed to comply with the standard
+- **EXAMPLE**: `--btn-dsp` SHALL be changed to `--btn-display`, `--card-p` SHALL be changed to `--card-padding`
+
+### Requirement: Variable Discovery and IDE Support
+
+CSS custom properties SHALL be organized to optimize IDE autocomplete and variable discovery, enabling developers to efficiently find and customize component styles.
+
+The hierarchical naming pattern SHALL group related variables by typing component prefixes, allowing developers to:
+1. Type `--{component}-` to see all component variables
+2. Type `--{component}-{variant}-` to see all variant-specific variables
+3. Type `--{component}-{state}-` to see all state-specific variables
+4. Type `--{component}-{element}-` to see all element-specific variables
+
+Components SHALL define variables in a predictable order: base properties, variant properties, state properties, element properties.
+
+#### Scenario: Discovering all button properties
+
+- **WHEN** a developer types `--btn-` in their IDE
+- **THEN** the autocomplete SHALL show all button-related variables
+- **AND** the variables SHALL be grouped logically (base, primary, secondary, hover, focus, disabled)
+- **EXAMPLE**: `--btn-bg`, `--btn-padding`, `--btn-primary-bg`, `--btn-hover-bg`, `--btn-focus-outline`
+
+#### Scenario: Discovering variant-specific properties
+
+- **WHEN** a developer types `--alert-error-` in their IDE
+- **THEN** the autocomplete SHALL show all error alert variables
+- **AND** all error-related styling SHALL be discoverable
+- **EXAMPLE**: `--alert-error-bg`, `--alert-error-border`, `--alert-error-color`
+
+#### Scenario: Discovering state-specific properties
+
+- **WHEN** a developer types `--btn-hover-` in their IDE
+- **THEN** the autocomplete SHALL show all hover state variables
+- **AND** all hover styling SHALL be grouped together
+- **EXAMPLE**: `--btn-hover-bg`, `--btn-hover-transform`, `--btn-hover-filter`
+
+### Requirement: Migration Documentation
+
+When CSS custom property names change due to refactoring, the library SHALL provide comprehensive migration documentation to help users update their customizations.
+
+Migration documentation SHALL include:
+1. A complete mapping of old variable names to new variable names
+2. Find-and-replace patterns with regex examples
+3. Component-by-component change lists
+4. Code examples showing before and after customization
+5. Testing guidance to verify migrations
+6. Rollback instructions if issues occur
+
+The library SHALL publish migration guides as part of major version releases that include breaking changes to CSS variable names.
+
+#### Scenario: Migrating renamed variables
+
+- **WHEN** a CSS variable is renamed in a breaking change
+- **THEN** the migration guide SHALL list the old name and new name
+- **AND** the guide SHALL provide a find-and-replace pattern
+- **EXAMPLE**: `--btn-px` → `--btn-padding-inline`, find pattern: `--btn-px\b`, replace with: `--btn-padding-inline`
+
+#### Scenario: Testing migrated customizations
+
+- **WHEN** a user completes variable name migration
+- **THEN** the migration guide SHALL provide a testing checklist
+- **AND** the checklist SHALL include visual verification steps
+- **EXAMPLE**: "1. Check button variants render correctly, 2. Verify hover states, 3. Test in both light and dark themes"
+
+#### Scenario: Understanding breaking changes
+
+- **WHEN** a user reads a CHANGELOG for a major version
+- **THEN** the changelog SHALL clearly mark CSS variable breaking changes
+- **AND** the changelog SHALL link to the migration guide
+- **EXAMPLE**: "**BREAKING**: CSS variables renamed for consistency. See [MIGRATION.md](./MIGRATION.md) for details."
+
+#### Scenario: Rolling back migration
+
+- **WHEN** a user encounters issues after migrating variables
+- **THEN** the migration guide SHALL provide rollback instructions
+- **AND** the instructions SHALL allow reverting to previous version
+- **EXAMPLE**: "To rollback: 1. Revert CSS changes, 2. Downgrade package version: `npm install @fpkit/acss@0.5.x`"
+
+### Requirement: Documentation and Reference
+
+The library SHALL maintain a comprehensive CSS Variable Reference Guide that documents the naming convention, approved abbreviations, and all available CSS custom properties for each component.
+
+The reference guide SHALL include:
+1. Explanation of the naming pattern with examples
+2. Complete list of approved abbreviations with rationale
+3. Component-by-component variable tables with descriptions
+4. Real-world customization examples (at least 5 scenarios)
+5. IDE setup tips for better autocomplete
+6. Links to migration guides for major versions
+
+The reference guide SHALL be updated whenever:
+- New components are added with CSS variables
+- Existing components add new customizable properties
+- The naming standard is updated through OpenSpec proposals
+
+#### Scenario: Finding all button variables
+
+- **WHEN** a developer wants to customize a button
+- **THEN** the CSS Variable Reference Guide SHALL list all button variables
+- **AND** each variable SHALL have a description explaining its purpose
+- **EXAMPLE**: Table with columns: Variable Name, Description, Default Value, Example Usage
+
+#### Scenario: Learning the naming pattern
+
+- **WHEN** a new contributor adds a component
+- **THEN** the CSS Variable Reference Guide SHALL explain the naming pattern
+- **AND** the guide SHALL provide examples for different component types
+- **EXAMPLE**: "Simple components (Badge): `--badge-bg`, Complex components with elements (Card): `--card-header-padding`"
+
+#### Scenario: Customizing component theme
+
+- **WHEN** a user wants to apply custom brand colors
+- **THEN** the CSS Variable Reference Guide SHALL provide theme customization examples
+- **AND** the examples SHALL show complete working code
+- **EXAMPLE**: Code snippet showing how to override `--btn-primary-bg`, `--btn-primary-color`, and `--btn-hover-bg` for brand consistency

--- a/openspec/changes/establish-css-variable-naming-standard/tasks.md
+++ b/openspec/changes/establish-css-variable-naming-standard/tasks.md
@@ -1,0 +1,99 @@
+# Implementation Tasks
+
+## 1. CSS Variable Reference Guide
+
+- [ ] 1.1 Create `docs/css-variables.md` file
+- [ ] 1.2 Write "Introduction" section explaining CSS variable customization
+- [ ] 1.3 Document "Naming Convention Pattern" with structure explanation
+- [ ] 1.4 Create "Approved Abbreviations" table with rationale
+- [ ] 1.5 Add "Variant Organization" section with examples
+- [ ] 1.6 Add "State Variables" section with common states
+- [ ] 1.7 Add "Element-Specific Variables" section with scoping rules
+- [ ] 1.8 Create "Pattern Examples" section with 5+ real-world scenarios
+- [ ] 1.9 Add "Component Variable Reference" - table listing all components and their variables
+- [ ] 1.10 Include "Customization Examples" showing how to override variables in user code
+- [ ] 1.11 Add "IDE Setup Tips" for better autocomplete experience
+- [ ] 1.12 Include "Migration from Old Names" section (reference template)
+
+## 2. Migration Guide Template
+
+- [ ] 2.1 Create `MIGRATION-template.md` file
+- [ ] 2.2 Write "Overview" explaining why variables are being renamed
+- [ ] 2.3 Create "Quick Reference" table with old name → new name mappings
+- [ ] 2.4 Add "Find and Replace Patterns" section with regex examples
+- [ ] 2.5 Document "Component-by-Component Changes" template structure
+- [ ] 2.6 Include "Testing Your Migration" checklist
+- [ ] 2.7 Add "Rollback Instructions" if migration causes issues
+- [ ] 2.8 Create "Common Migration Scenarios" with code examples
+- [ ] 2.9 Add "Storybook Customization Examples" showing new variable usage
+- [ ] 2.10 Include "FAQ" section addressing common migration questions
+
+## 3. Update Contribution Guidelines
+
+- [ ] 3.1 Read current `packages/fpkit/CLAUDE.md`
+- [ ] 3.2 Add "CSS Variable Naming Standard" section to Styling System
+- [ ] 3.3 Document the naming pattern with examples
+- [ ] 3.4 Add "Approved Abbreviations" quick reference
+- [ ] 3.5 Include "Examples for New Components" showing how to apply standard
+- [ ] 3.6 Add checklist item for PR reviews: "CSS variables follow naming standard"
+- [ ] 3.7 Reference `docs/css-variables.md` for detailed documentation
+- [ ] 3.8 Update "Component Development Workflow" with variable naming step
+
+## 4. Create Examples and Code Snippets
+
+- [ ] 4.1 Create example: Basic button customization
+- [ ] 4.2 Create example: Alert variant customization
+- [ ] 4.3 Create example: Form input theming
+- [ ] 4.4 Create example: Card with header/footer styling
+- [ ] 4.5 Create example: Responsive variable values
+- [ ] 4.6 Create example: Dark mode theming
+- [ ] 4.7 Create example: Custom brand colors
+- [ ] 4.8 Create example: Typography scale customization
+- [ ] 4.9 Add all examples to CSS Variable Reference Guide
+- [ ] 4.10 Test all examples in Storybook to ensure they work
+
+## 5. Documentation Review and Polish
+
+- [ ] 5.1 Proofread all documentation for clarity and consistency
+- [ ] 5.2 Verify all code examples have proper syntax highlighting
+- [ ] 5.3 Check that all links and references are correct
+- [ ] 5.4 Ensure examples follow the established standard
+- [ ] 5.5 Get peer review from team member
+- [ ] 5.6 Incorporate feedback from review
+- [ ] 5.7 Final spell-check and grammar review
+
+## 6. Integration and Publishing
+
+- [ ] 6.1 Commit documentation files to repository
+- [ ] 6.2 Update root README.md to link to CSS Variable Reference Guide (if applicable)
+- [ ] 6.3 Ensure documentation is discoverable in project navigation
+- [ ] 6.4 Add link to CSS variables docs in Storybook (if possible)
+- [ ] 6.5 Announce new documentation to team/users
+
+## 7. Validation
+
+- [ ] 7.1 Verify standard covers all existing component patterns
+- [ ] 7.2 Test that pattern works for complex components (Alert, Dialog)
+- [ ] 7.3 Test that pattern works for simple components (Badge, Tag)
+- [ ] 7.4 Validate that IDE autocomplete works as expected
+- [ ] 7.5 Ensure migration guide is actionable and complete
+- [ ] 7.6 Confirm examples actually work when applied
+
+## Notes
+
+- All tasks are documentation-only; no code changes required
+- Documentation should be written in Markdown
+- Examples should use real component names from the library
+- Keep documentation concise but comprehensive
+- Use tables and code blocks for better readability
+- Link between related documentation sections
+
+## Acceptance Criteria
+
+- [ ] CSS Variable Reference Guide is complete and published
+- [ ] Migration Guide Template is ready for implementation proposals
+- [ ] CLAUDE.md includes CSS variable naming standard
+- [ ] At least 8 real-world customization examples documented
+- [ ] All documentation reviewed and approved by team
+- [ ] Examples tested and verified to work
+- [ ] Documentation is easily discoverable in the project

--- a/openspec/changes/refactor-core-component-css-variables/proposal.md
+++ b/openspec/changes/refactor-core-component-css-variables/proposal.md
@@ -1,0 +1,312 @@
+# Refactor Core Component CSS Variables
+
+## Why
+
+The Button, Form/Input, and Card components collectively represent **~60% of user customization scenarios** in the @fpkit/acss library, yet they currently use inconsistent, abbreviated CSS variable names that create friction for users:
+
+**Button Component Problems (26 variables):**
+- Heavy abbreviations: `--btn-fs`, `--btn-rds`, `--btn-cl`, `--btn-dsp`, `--btn-bdr`
+- Ambiguous logical properties: `--btn-px`, `--btn-py` (what does `px` mean?)
+- Mixed naming: `--btn-hov-bg` inconsistent with other state variables
+
+**Form/Input Component Problems (12 variables):**
+- Inconsistent abbreviations: `--input-px`, `--input-py`, `--input-w`, `--input-fs`
+- Mix of patterns: some abbreviated, some full words
+- Missing state variables for focus, disabled states
+
+**Card Component Problems (8 variables):**
+- Single-letter abbreviation: `--card-p` instead of `--card-padding`
+- Lacks element scoping for complex card layouts (header, footer, body)
+
+**User Impact:**
+- Users must reference SCSS files to discover variable names
+- IDE autocomplete is less effective due to inconsistent prefixes
+- Learning curve is higher than necessary
+- Poor first impression for new library users
+
+These three components are the **highest leverage targets** for improvement. Refactoring them will:
+1. Demonstrate the value of the new naming standard
+2. Provide immediate benefits to the most common customization scenarios
+3. Serve as templates for refactoring remaining components
+
+## What Changes
+
+This proposal implements the CSS variable naming standard (from `establish-css-variable-naming-standard`) for Button, Form/Input, and Card components.
+
+### Button Component Refactoring
+
+**BREAKING**: Rename 26 CSS variables to follow naming standard.
+
+**Key Changes:**
+```scss
+// Size tokens - keep pattern, rename for clarity
+--btn-xs → --btn-size-xs
+--btn-sm → --btn-size-sm
+--btn-md → --btn-size-md
+--btn-lg → --btn-size-lg
+
+// Base properties - expand abbreviations
+--btn-px → --btn-padding-inline
+--btn-py → --btn-padding-block
+--btn-rds → --btn-radius
+--btn-cl → --btn-color
+--btn-dsp → --btn-display
+--btn-bdr → --btn-border
+--btn-wspc → --btn-whitespace
+--btn-spc → --btn-spacing
+
+// Keep approved abbreviations
+--btn-fs (font-size) ✓
+--btn-bg (background) ✓
+--btn-fw (font-weight) ✓
+
+// State variables - standardize naming
+--btn-hov-bg → --btn-hover-bg
+--btn-hover-filter ✓ (already correct)
+--btn-hover-transform ✓ (already correct)
+
+// Add explicit variant variables
+--btn-primary-bg (NEW)
+--btn-primary-color (NEW)
+--btn-secondary-bg (NEW)
+--btn-secondary-border (NEW)
+```
+
+**Total**: 26 variables renamed/reorganized
+
+### Form/Input Component Refactoring
+
+**BREAKING**: Rename 12 CSS variables and add state variables.
+
+**Key Changes:**
+```scss
+// Expand abbreviations
+--input-px → --input-padding-inline
+--input-py → --input-padding-block
+--input-w → --input-width
+--input-fs ✓ (approved abbreviation)
+
+// Add missing state variables
+--input-focus-outline (NEW)
+--input-focus-outline-offset (NEW)
+--input-disabled-bg (NEW)
+--input-disabled-opacity (NEW)
+
+// Placeholder variables
+--placeholder-fs ✓ (approved abbreviation)
+--placeholder-color ✓ (already correct)
+```
+
+**Total**: 12 variables renamed, 4 new state variables added
+
+### Card Component Refactoring
+
+**BREAKING**: Rename 8 variables and add element-specific scoping.
+
+**Key Changes:**
+```scss
+// Expand abbreviation
+--card-p → --card-padding
+
+// Base properties (already good)
+--card-bg ✓
+--card-radius ✓
+--card-display ✓
+--card-direction ✓
+--card-gap ✓
+
+// Add element-specific variables (NEW)
+--card-header-padding (NEW)
+--card-header-bg (NEW)
+--card-header-border-bottom (NEW)
+--card-body-padding (NEW)
+--card-footer-padding (NEW)
+--card-footer-bg (NEW)
+```
+
+**Total**: 1 variable renamed, 6 element-scoped variables added
+
+### Additional Changes
+
+1. **Update Storybook Controls**: Add controls for new/renamed variables in stories
+2. **Update Component Implementations**: Reference new variable names in SCSS
+3. **Migration Documentation**: Create component-specific migration tables
+4. **Storybook Examples**: Add customization examples using new variables
+
+## Impact
+
+### Affected Specs
+- `specs/ui-component/spec.md` - **ADDED** requirements for component theming
+
+### Affected Code
+
+**SCSS Files (Breaking Changes):**
+- `packages/fpkit/src/components/buttons/button.scss` - 26 variables refactored
+- `packages/fpkit/src/components/form/form.scss` - 12 variables refactored
+- `packages/fpkit/src/components/cards/card.scss` - 8 variables refactored
+
+**Storybook Files (Non-Breaking):**
+- `packages/fpkit/src/components/buttons/button.stories.tsx` - Update controls/examples
+- `packages/fpkit/src/components/form/form.stories.tsx` - Update controls/examples
+- `packages/fpkit/src/components/cards/card.stories.tsx` - Update controls/examples
+
+**Component Files (No Changes):**
+- Component TypeScript files remain unchanged (CSS-only changes)
+
+**Documentation (New Files):**
+- `MIGRATION-v{X}.md` - Complete migration guide with before/after tables
+- Update `CHANGELOG.md` with breaking changes section
+
+### Breaking Changes
+
+**YES** - This is a **BREAKING CHANGE** requiring a major version bump.
+
+**User Impact:**
+- Any custom CSS that overrides these variables will break
+- Users must update their stylesheets to use new variable names
+- Find-and-replace migration is straightforward (documented in migration guide)
+
+**Mitigation:**
+1. **Migration Guide**: Complete before/after mapping for all 46 variables
+2. **Find-Replace Patterns**: Regex patterns for automated migration
+3. **Beta Release**: Publish beta for user testing before final release
+4. **CHANGELOG**: Clear breaking changes section with migration link
+5. **Examples**: Update all Storybook examples to demonstrate new variables
+
+### Benefits
+
+**For Users:**
+- ✅ Predictable variable names across core components
+- ✅ Better IDE autocomplete (type `--btn-` to see all button properties)
+- ✅ Clearer logical properties (`--btn-padding-inline` vs `--btn-px`)
+- ✅ Improved discoverability of customization options
+- ✅ Consistent with modern CSS best practices
+
+**For Maintainers:**
+- ✅ Template for refactoring remaining components
+- ✅ Validation of naming standard in real-world usage
+- ✅ Improved code readability
+- ✅ Easier onboarding for new contributors
+
+**For the Library:**
+- ✅ Professional, polished developer experience
+- ✅ Competitive with other design systems
+- ✅ Strong foundation for future components
+
+### Performance Impact
+
+**None** - CSS custom property names have no runtime performance impact. Variables are resolved at render time regardless of name length.
+
+### Accessibility Impact
+
+**None** - This is purely a CSS variable naming change. Component functionality, ARIA attributes, and keyboard interactions remain unchanged.
+
+### Timeline
+
+**Implementation:** 2-3 weeks
+- Week 1: Button + Form refactoring + testing
+- Week 2: Card refactoring + migration guide + Storybook updates
+- Week 3: Beta release + user feedback + final release
+
+### Dependencies
+
+**Required Before Implementation:**
+- ✅ `establish-css-variable-naming-standard` proposal MUST be approved first
+- ✅ CSS Variable Reference Guide published
+- ✅ Migration guide template available
+
+**Blocks:**
+- Future refactoring proposals for remaining components (should wait for feedback from this)
+
+### Risks and Mitigation
+
+**Risk 1: Users resist breaking changes**
+- *Probability*: Medium
+- *Impact*: High
+- *Mitigation*: Comprehensive migration guide, beta testing period, clear communication of benefits
+
+**Risk 2: Migration guide inadequate**
+- *Probability*: Low
+- *Impact*: High
+- *Mitigation*: Include complete before/after tables, regex patterns, and test all examples
+
+**Risk 3: Missed variable references**
+- *Probability*: Low
+- *Impact*: Medium
+- *Mitigation*: Grep for all old variable names, test all component variants in Storybook, run full test suite
+
+**Risk 4: Breaking changes in patch instead of major**
+- *Probability*: Very Low
+- *Impact*: High
+- *Mitigation*: Enforce major version bump in PR review, automated version checking
+
+## Success Criteria
+
+- [ ] All 46 variables renamed according to naming standard
+- [ ] All component variants render correctly with new variables
+- [ ] Storybook stories updated with new variable names in controls
+- [ ] Migration guide complete with before/after tables for all variables
+- [ ] CHANGELOG documents all breaking changes clearly
+- [ ] All existing tests pass without modifications
+- [ ] Visual regression tests show no differences
+- [ ] Build succeeds without errors
+- [ ] Lint passes without errors
+- [ ] Beta version published and tested by at least 2 users
+- [ ] At least 3 customization examples documented per component
+
+## Alternatives Considered
+
+### Alternative 1: Refactor all components at once
+
+**Rejected**: Too risky, harder to test, longer delay before users get value.
+
+### Alternative 2: Maintain backward compatibility with CSS variable aliases
+
+**Example:**
+```scss
+--btn-px: var(--btn-padding-inline);  // Alias for compatibility
+```
+
+**Rejected**:
+- Doubles maintenance burden (must maintain both names)
+- Perpetuates bad patterns
+- Users won't migrate if old names still work
+- Clean break is clearer
+
+### Alternative 3: Start with less critical components
+
+**Rejected**: Button/Form/Card are the highest value targets. Starting with less-used components would delay benefits to users.
+
+### Alternative 4: Add new variables without removing old ones
+
+**Rejected**: Would create even more inconsistency. Users wouldn't know which variables to use.
+
+## Next Steps
+
+After approval:
+1. **Pre-implementation**:
+   - Ensure `establish-css-variable-naming-standard` is approved
+   - Review CSS Variable Reference Guide
+   - Confirm migration guide template is ready
+
+2. **Implementation** (Week 1-2):
+   - Refactor Button SCSS
+   - Refactor Form/Input SCSS
+   - Refactor Card SCSS
+   - Update Storybook stories
+   - Run full test suite
+
+3. **Documentation** (Week 2):
+   - Create MIGRATION-v{X}.md with complete mappings
+   - Update CHANGELOG.md
+   - Add customization examples to docs
+
+4. **Testing** (Week 2-3):
+   - Visual regression testing
+   - Beta release for user testing
+   - Gather feedback
+
+5. **Release** (Week 3):
+   - Bump major version
+   - Final release with migration notes
+   - Communicate breaking changes to users

--- a/openspec/changes/refactor-core-component-css-variables/specs/ui-component/spec.md
+++ b/openspec/changes/refactor-core-component-css-variables/specs/ui-component/spec.md
@@ -1,0 +1,253 @@
+# UI Component Specification - CSS Variable Refactoring
+
+## ADDED Requirements
+
+### Requirement: Button Component CSS Variables
+
+The Button component SHALL provide CSS custom properties following the established naming convention to enable users to customize button appearance consistently across all variants and states.
+
+Button CSS variables SHALL follow the pattern `--btn-{variant|state}-{property}` where properties use approved abbreviations (`bg`, `fs`, `fw`) or full words for clarity.
+
+The Button component SHALL support:
+1. Size tokens for consistent sizing across variants
+2. Base property customization (padding, border, colors, typography)
+3. Variant-specific styling (primary, secondary, tertiary)
+4. State-specific styling (hover, focus, disabled, active)
+
+All button CSS variables SHALL use logical properties (`padding-inline`, `padding-block`) for better internationalization support.
+
+#### Scenario: Customizing button base properties
+
+- **WHEN** a user wants to customize the default button appearance
+- **THEN** they SHALL be able to override base property variables
+- **AND** the variables SHALL use clear, predictable names
+- **EXAMPLE**: Override `--btn-padding-inline`, `--btn-padding-block`, `--btn-radius`, `--btn-bg`, `--btn-color`
+
+#### Scenario: Customizing button size tokens
+
+- **WHEN** a user wants to adjust button sizes
+- **THEN** they SHALL override size token variables
+- **AND** size tokens SHALL follow the pattern `--btn-size-{size}`
+- **EXAMPLE**: `--btn-size-xs: 0.75rem`, `--btn-size-sm: 0.875rem`, `--btn-size-md: 1rem`, `--btn-size-lg: 1.25rem`
+
+#### Scenario: Customizing button variant colors
+
+- **WHEN** a user wants to apply custom brand colors to button variants
+- **THEN** they SHALL override variant-specific color variables
+- **AND** variant variables SHALL follow the pattern `--btn-{variant}-{property}`
+- **EXAMPLE**: `--btn-primary-bg: #0066cc`, `--btn-primary-color: white`, `--btn-secondary-bg: transparent`, `--btn-secondary-border: 1px solid currentColor`
+
+#### Scenario: Customizing button hover states
+
+- **WHEN** a user wants to customize button hover effects
+- **THEN** they SHALL override state-specific variables
+- **AND** state variables SHALL follow the pattern `--btn-hover-{property}`
+- **EXAMPLE**: `--btn-hover-bg: #0052a3`, `--btn-hover-transform: translateY(-1px)`, `--btn-hover-filter: brightness(1.05)`
+
+#### Scenario: Customizing button focus indicators
+
+- **WHEN** a user wants to customize focus styles for accessibility
+- **THEN** they SHALL override focus-specific variables
+- **AND** focus variables SHALL follow the pattern `--btn-focus-{property}`
+- **EXAMPLE**: `--btn-focus-outline: 2px solid currentColor`, `--btn-focus-outline-offset: 2px`
+
+#### Scenario: Using logical properties for padding
+
+- **WHEN** button padding is customized
+- **THEN** the variables SHALL use logical property names
+- **AND** logical properties SHALL be spelled out fully (not abbreviated)
+- **EXAMPLE**: `--btn-padding-inline` (NOT `--btn-px`), `--btn-padding-block` (NOT `--btn-py`)
+
+### Requirement: Form Input Component CSS Variables
+
+The Form/Input component SHALL provide CSS custom properties following the established naming convention to enable users to customize input field appearance and states.
+
+Form input CSS variables SHALL follow the pattern `--input-{state}-{property}` where properties use approved abbreviations or full words.
+
+The Form/Input component SHALL support:
+1. Base property customization (padding, border, background, typography)
+2. State-specific styling (focus, disabled, error, valid)
+3. Placeholder styling
+4. Consistent sizing with logical properties
+
+#### Scenario: Customizing input base properties
+
+- **WHEN** a user wants to customize the default input appearance
+- **THEN** they SHALL be able to override base property variables
+- **AND** the variables SHALL use clear names with logical properties
+- **EXAMPLE**: `--input-padding-inline`, `--input-padding-block`, `--input-border`, `--input-bg`, `--input-color`, `--input-radius`
+
+#### Scenario: Customizing input focus state
+
+- **WHEN** a user wants to customize input focus indicators for accessibility
+- **THEN** they SHALL override focus-specific variables
+- **AND** focus outline SHALL meet WCAG 2.4.7 requirements (3:1 contrast ratio)
+- **EXAMPLE**: `--input-focus-outline: 2px solid #0066cc`, `--input-focus-outline-offset: 0`, `--input-focus-border-color: #0066cc`
+
+#### Scenario: Customizing input disabled state
+
+- **WHEN** a user wants to customize disabled input appearance
+- **THEN** they SHALL override disabled-specific variables
+- **AND** disabled styles SHALL clearly indicate non-interactive state
+- **EXAMPLE**: `--input-disabled-bg: #e9ecef`, `--input-disabled-opacity: 0.6`, `--input-disabled-cursor: not-allowed`
+
+#### Scenario: Customizing placeholder text
+
+- **WHEN** a user wants to customize placeholder styling
+- **THEN** they SHALL override placeholder-specific variables
+- **AND** placeholder variables SHALL follow the pattern `--placeholder-{property}`
+- **EXAMPLE**: `--placeholder-color: #6c757d`, `--placeholder-fs: 0.875rem`, `--placeholder-style: italic`
+
+#### Scenario: Using logical properties for input padding
+
+- **WHEN** input padding is customized
+- **THEN** the variables SHALL use logical property names
+- **AND** logical properties SHALL be spelled out fully
+- **EXAMPLE**: `--input-padding-inline: 0.75rem` (NOT `--input-px`), `--input-padding-block: 0.5rem` (NOT `--input-py`)
+
+#### Scenario: Customizing input width
+
+- **WHEN** a user wants to control default input width
+- **THEN** they SHALL override the width variable using the full word
+- **AND** the variable SHALL NOT use single-letter abbreviations
+- **EXAMPLE**: `--input-width: 100%` (NOT `--input-w`)
+
+### Requirement: Card Component CSS Variables
+
+The Card component SHALL provide CSS custom properties following the established naming convention to enable users to customize card layout and element-specific styling.
+
+Card CSS variables SHALL follow the pattern `--card-{element}-{property}` where element represents sub-components (header, body, footer) when applicable.
+
+The Card component SHALL support:
+1. Base card property customization (padding, background, border, layout)
+2. Element-specific styling for complex card layouts (header, body, footer)
+3. Consistent naming without single-letter abbreviations
+
+#### Scenario: Customizing card base properties
+
+- **WHEN** a user wants to customize the default card appearance
+- **THEN** they SHALL be able to override base property variables
+- **AND** the variables SHALL use full property names
+- **EXAMPLE**: `--card-padding: 1.5rem` (NOT `--card-p`), `--card-bg: white`, `--card-radius: 0.5rem`, `--card-gap: 1rem`
+
+#### Scenario: Customizing card header
+
+- **WHEN** a user wants to customize card header styling separately
+- **THEN** they SHALL override header-specific variables
+- **AND** header variables SHALL follow the pattern `--card-header-{property}`
+- **EXAMPLE**: `--card-header-padding: 1rem 1.5rem`, `--card-header-bg: #f8f9fa`, `--card-header-border-bottom: 1px solid #dee2e6`
+
+#### Scenario: Customizing card body
+
+- **WHEN** a user wants to customize card body styling separately
+- **THEN** they SHALL override body-specific variables
+- **AND** body variables SHALL follow the pattern `--card-body-{property}`
+- **EXAMPLE**: `--card-body-padding: 1.5rem`, `--card-body-gap: 1rem`
+
+#### Scenario: Customizing card footer
+
+- **WHEN** a user wants to customize card footer styling separately
+- **THEN** they SHALL override footer-specific variables
+- **AND** footer variables SHALL follow the pattern `--card-footer-{property}`
+- **EXAMPLE**: `--card-footer-padding: 1rem 1.5rem`, `--card-footer-bg: #f8f9fa`, `--card-footer-border-top: 1px solid #dee2e6`
+
+#### Scenario: Using full property names for card padding
+
+- **WHEN** card padding is customized
+- **THEN** the variable SHALL use the full word "padding"
+- **AND** single-letter abbreviations SHALL NOT be used
+- **EXAMPLE**: `--card-padding: 1.5rem` (NOT `--card-p`)
+
+#### Scenario: Customizing card layout properties
+
+- **WHEN** a user wants to control card layout behavior
+- **THEN** they SHALL override layout-specific variables
+- **AND** layout variables SHALL use full CSS property names
+- **EXAMPLE**: `--card-display: flex`, `--card-direction: column`, `--card-gap: 1rem`, `--card-align: stretch`
+
+### Requirement: CSS Variable Migration Support
+
+When CSS custom property names are changed in a breaking release, the library SHALL provide comprehensive migration documentation and tooling to help users update their customizations.
+
+Migration support SHALL include:
+1. Complete before/after mapping of all changed variables
+2. Find-and-replace patterns with regex examples
+3. Component-by-component migration tables
+4. Verification checklist for testing migrations
+5. Rollback instructions if issues occur
+
+#### Scenario: Finding old variable names in codebase
+
+- **WHEN** a user needs to migrate from old variable names
+- **THEN** the migration guide SHALL provide regex patterns for finding old names
+- **AND** patterns SHALL account for word boundaries to avoid partial matches
+- **EXAMPLE**: Find pattern: `--btn-px\b`, Replace: `--btn-padding-inline`
+
+#### Scenario: Migrating button variables
+
+- **WHEN** a user needs to update button customizations
+- **THEN** the migration guide SHALL provide a complete table of button variable changes
+- **AND** the table SHALL include old name, new name, and example usage
+- **EXAMPLE TABLE**:
+  | Old Variable | New Variable | Example Value |
+  |---|---|---|
+  | `--btn-px` | `--btn-padding-inline` | `1rem` |
+  | `--btn-py` | `--btn-padding-block` | `0.5rem` |
+  | `--btn-rds` | `--btn-radius` | `0.375rem` |
+
+#### Scenario: Verifying migration success
+
+- **WHEN** a user completes variable name migration
+- **THEN** the migration guide SHALL provide a testing checklist
+- **AND** the checklist SHALL include visual and functional verification steps
+- **EXAMPLE CHECKLIST**:
+  - [ ] All button variants render correctly
+  - [ ] Hover states work as expected
+  - [ ] Focus indicators are visible
+  - [ ] Form inputs have correct styling
+  - [ ] Cards display properly with custom styles
+
+#### Scenario: Rolling back after migration issues
+
+- **WHEN** a user encounters problems after migrating
+- **THEN** the migration guide SHALL provide rollback instructions
+- **AND** instructions SHALL include version downgrade steps
+- **EXAMPLE**: "To rollback: 1. Revert CSS changes, 2. Run `npm install @fpkit/acss@0.5.11`"
+
+### Requirement: Storybook Customization Examples
+
+Each refactored component SHALL include Storybook stories demonstrating CSS variable customization using the new naming convention.
+
+Storybook customization examples SHALL show:
+1. Basic property overrides with new variable names
+2. Variant-specific customization
+3. State-specific customization
+4. Complete theme customization scenarios
+
+#### Scenario: Button customization example in Storybook
+
+- **WHEN** a developer views Button stories in Storybook
+- **THEN** there SHALL be a "Customization" story showing variable overrides
+- **AND** the story SHALL include code examples with new variable names
+- **EXAMPLE**: Story showing how to override `--btn-primary-bg`, `--btn-padding-inline`, `--btn-radius` for custom branding
+
+#### Scenario: Form input customization example
+
+- **WHEN** a developer views Form/Input stories in Storybook
+- **THEN** there SHALL be a "Customization" story showing focus and disabled state styling
+- **AND** the story SHALL include accessibility-compliant focus indicator examples
+- **EXAMPLE**: Story showing `--input-focus-outline`, `--input-disabled-bg` customization
+
+#### Scenario: Card customization example
+
+- **WHEN** a developer views Card stories in Storybook
+- **THEN** there SHALL be a "Customization" story showing element-specific styling
+- **AND** the story SHALL demonstrate header, body, and footer customization
+- **EXAMPLE**: Story showing `--card-header-bg`, `--card-body-padding`, `--card-footer-border-top` usage
+
+#### Scenario: Dark theme example
+
+- **WHEN** a developer wants to implement dark mode theming
+- **THEN** Storybook stories SHALL include dark theme customization examples
+- **AND** examples SHALL show how to override multiple variables for cohesive theming
+- **EXAMPLE**: Dark mode story overriding button, input, and card background/color variables

--- a/openspec/changes/refactor-core-component-css-variables/tasks.md
+++ b/openspec/changes/refactor-core-component-css-variables/tasks.md
@@ -1,0 +1,218 @@
+# Implementation Tasks
+
+## 1. Button Component Refactoring
+
+- [ ] 1.1 Read current `packages/fpkit/src/components/buttons/button.scss`
+- [ ] 1.2 Create backup of button.scss
+- [ ] 1.3 Refactor size tokens: `--btn-xs` → `--btn-size-xs`, etc. (4 variables)
+- [ ] 1.4 Refactor logical properties: `--btn-px` → `--btn-padding-inline`, `--btn-py` → `--btn-padding-block`
+- [ ] 1.5 Refactor visual properties: `--btn-rds` → `--btn-radius`, `--btn-cl` → `--btn-color`, `--btn-dsp` → `--btn-display`, `--btn-bdr` → `--btn-border`
+- [ ] 1.6 Refactor whitespace/spacing: `--btn-wspc` → `--btn-whitespace`, `--btn-spc` → `--btn-spacing`
+- [ ] 1.7 Standardize state variables: `--btn-hov-bg` → `--btn-hover-bg`
+- [ ] 1.8 Add explicit variant variables: `--btn-primary-bg`, `--btn-primary-color`, `--btn-secondary-bg`, `--btn-secondary-border`
+- [ ] 1.9 Update all references within button.scss to use new names
+- [ ] 1.10 Verify button component renders correctly in browser
+- [ ] 1.11 Test all button variants (sizes, colors, states)
+- [ ] 1.12 Test button hover states
+- [ ] 1.13 Test button focus states
+- [ ] 1.14 Test button disabled state
+- [ ] 1.15 Update `button.stories.tsx` to use new variable names in controls
+- [ ] 1.16 Add Storybook customization examples with new variables
+- [ ] 1.17 Run `npm run lint` on button files
+- [ ] 1.18 Run `npm run sass:build` to compile SCSS
+- [ ] 1.19 Verify no TypeScript errors in button component
+- [ ] 1.20 Create migration table for button variables (old → new)
+
+## 2. Form/Input Component Refactoring
+
+- [ ] 2.1 Read current `packages/fpkit/src/components/form/form.scss`
+- [ ] 2.2 Create backup of form.scss
+- [ ] 2.3 Refactor logical properties: `--input-px` → `--input-padding-inline`, `--input-py` → `--input-padding-block`
+- [ ] 2.4 Refactor sizing: `--input-w` → `--input-width`
+- [ ] 2.5 Keep approved abbreviations: `--input-fs` (font-size)
+- [ ] 2.6 Add missing focus state variables: `--input-focus-outline`, `--input-focus-outline-offset`
+- [ ] 2.7 Add missing disabled state variables: `--input-disabled-bg`, `--input-disabled-opacity`
+- [ ] 2.8 Update placeholder variables if needed: `--placeholder-fs`, `--placeholder-color`
+- [ ] 2.9 Update all references within form.scss to use new names
+- [ ] 2.10 Verify input renders correctly in browser
+- [ ] 2.11 Test input focus state
+- [ ] 2.12 Test input disabled state
+- [ ] 2.13 Test input error state (if applicable)
+- [ ] 2.14 Test textarea variant
+- [ ] 2.15 Test select variant
+- [ ] 2.16 Update form/input stories with new variable names
+- [ ] 2.17 Add Storybook customization examples
+- [ ] 2.18 Run accessibility tests (focus indicators meet WCAG standards)
+- [ ] 2.19 Run `npm run lint` on form files
+- [ ] 2.20 Run `npm run sass:build` to compile SCSS
+- [ ] 2.21 Create migration table for form/input variables (old → new)
+
+## 3. Card Component Refactoring
+
+- [ ] 3.1 Read current `packages/fpkit/src/components/cards/card.scss`
+- [ ] 3.2 Create backup of card.scss
+- [ ] 3.3 Refactor abbreviated padding: `--card-p` → `--card-padding`
+- [ ] 3.4 Verify existing good variables: `--card-bg`, `--card-radius`, `--card-display`, `--card-direction`, `--card-gap`
+- [ ] 3.5 Add element-specific variables for complex cards: `--card-header-padding`, `--card-header-bg`, `--card-header-border-bottom`
+- [ ] 3.6 Add body element variables: `--card-body-padding`
+- [ ] 3.7 Add footer element variables: `--card-footer-padding`, `--card-footer-bg`
+- [ ] 3.8 Update all references within card.scss to use new names
+- [ ] 3.9 Verify card component renders correctly
+- [ ] 3.10 Test basic card layout
+- [ ] 3.11 Test card with header
+- [ ] 3.12 Test card with footer
+- [ ] 3.13 Test card with header + body + footer
+- [ ] 3.14 Update card.stories.tsx with new variable names
+- [ ] 3.15 Add Storybook examples showing element-specific customization
+- [ ] 3.16 Run `npm run lint` on card files
+- [ ] 3.17 Run `npm run sass:build` to compile SCSS
+- [ ] 3.18 Create migration table for card variables (old → new)
+
+## 4. Testing & Validation
+
+- [ ] 4.1 Run full test suite: `npm test`
+- [ ] 4.2 Verify all existing tests pass without modification
+- [ ] 4.3 Run Vitest with UI and coverage: `npm run test:ui`
+- [ ] 4.4 Verify no test coverage regressions
+- [ ] 4.5 Start Storybook: `npm start` (from root)
+- [ ] 4.6 Visually verify all button variants in Storybook
+- [ ] 4.7 Visually verify all form/input variants in Storybook
+- [ ] 4.8 Visually verify all card variants in Storybook
+- [ ] 4.9 Run Storybook accessibility addon checks
+- [ ] 4.10 Verify no new a11y violations
+- [ ] 4.11 Test in multiple browsers (Chrome, Firefox, Safari)
+- [ ] 4.12 Run full build: `npm run build` (from fpkit directory)
+- [ ] 4.13 Verify build succeeds without errors
+- [ ] 4.14 Check build output in `libs/` directory
+- [ ] 4.15 Run linter: `npm run lint`
+- [ ] 4.16 Fix any linting errors with `npm run lint-fix`
+- [ ] 4.17 Test in demo app (astro-builds) if applicable
+- [ ] 4.18 Verify compiled CSS contains new variable names
+- [ ] 4.19 Grep for old variable names to ensure none remain
+- [ ] 4.20 Visual regression testing (compare before/after screenshots)
+
+## 5. Migration Documentation
+
+- [ ] 5.1 Create `MIGRATION-v{X}.md` file in root
+- [ ] 5.2 Write "Overview" section explaining breaking changes
+- [ ] 5.3 Add "Quick Summary" with total number of changed variables
+- [ ] 5.4 Create "Button Component" section with before/after table (26 variables)
+- [ ] 5.5 Create "Form/Input Component" section with before/after table (12 variables)
+- [ ] 5.6 Create "Card Component" section with before/after table (8 variables)
+- [ ] 5.7 Add "Find and Replace Patterns" section with regex examples
+- [ ] 5.8 Include example: Find `--btn-px\b`, Replace `--btn-padding-inline`
+- [ ] 5.9 Add "Testing Your Migration" checklist
+- [ ] 5.10 Include "Before You Migrate" preparation steps
+- [ ] 5.11 Add "After Migration" verification steps
+- [ ] 5.12 Create "Common Migration Scenarios" with code examples
+- [ ] 5.13 Add "Troubleshooting" section for common issues
+- [ ] 5.14 Include "Rollback Instructions" if users encounter problems
+- [ ] 5.15 Add "Frequently Asked Questions" section
+- [ ] 5.16 Proofread migration guide for clarity
+- [ ] 5.17 Test all find-and-replace patterns on sample code
+- [ ] 5.18 Get peer review of migration guide
+
+## 6. CHANGELOG Updates
+
+- [ ] 6.1 Read current `CHANGELOG.md`
+- [ ] 6.2 Create new version section for major release
+- [ ] 6.3 Add "BREAKING CHANGES" subsection at top
+- [ ] 6.4 List all CSS variable changes with summary
+- [ ] 6.5 Link to migration guide: `See [MIGRATION-v{X}.md](./MIGRATION-v{X}.md)`
+- [ ] 6.6 Add "CSS Variables" section listing specific changes
+- [ ] 6.7 Document Button component changes
+- [ ] 6.8 Document Form/Input component changes
+- [ ] 6.9 Document Card component changes
+- [ ] 6.10 Add "Migration" section with quick tips
+- [ ] 6.11 Add "Benefits" section explaining improvements
+- [ ] 6.12 Include release date
+- [ ] 6.13 Follow existing CHANGELOG format/style
+- [ ] 6.14 Verify all links work
+
+## 7. Storybook Documentation
+
+- [ ] 7.1 Update button.stories.tsx controls to reflect new variable names
+- [ ] 7.2 Add "Customization" story for Button showing variable overrides
+- [ ] 7.3 Add code example in Button docs showing how to customize with new variables
+- [ ] 7.4 Update form.stories.tsx controls
+- [ ] 7.5 Add "Customization" story for Form/Input
+- [ ] 7.6 Add code example in Form docs
+- [ ] 7.7 Update card.stories.tsx controls
+- [ ] 7.8 Add "Customization" story for Card showing header/footer styling
+- [ ] 7.9 Add code example in Card docs
+- [ ] 7.10 Add "CSS Variables" section to each component's Storybook docs page
+- [ ] 7.11 List all available variables in docs
+- [ ] 7.12 Include default values where helpful
+- [ ] 7.13 Verify all Storybook stories load without errors
+- [ ] 7.14 Test interactive controls for new variables
+- [ ] 7.15 Ensure documentation renders correctly in Storybook
+
+## 8. Version Management
+
+- [ ] 8.1 Determine next major version number (e.g., 1.0.0 or 2.0.0)
+- [ ] 8.2 Update `packages/fpkit/package.json` version
+- [ ] 8.3 Verify version follows semantic versioning (major bump for breaking changes)
+- [ ] 8.4 Update root `package-lock.json` if needed
+- [ ] 8.5 Tag version for Lerna: `git tag v{X}.0.0`
+- [ ] 8.6 Verify package.json version matches CHANGELOG version
+
+## 9. Beta Release (Optional but Recommended)
+
+- [ ] 9.1 Create beta branch: `release/v{X}.0.0-beta`
+- [ ] 9.2 Publish beta to npm: `npm publish --tag beta`
+- [ ] 9.3 Announce beta release to users/team
+- [ ] 9.4 Create test project using beta version
+- [ ] 9.5 Apply migrations in test project
+- [ ] 9.6 Document any issues found
+- [ ] 9.7 Gather feedback from at least 2 beta testers
+- [ ] 9.8 Incorporate feedback and fix any issues
+- [ ] 9.9 Publish second beta if needed
+- [ ] 9.10 Confirm beta is stable before final release
+
+## 10. Final Release
+
+- [ ] 10.1 Merge all changes to main branch
+- [ ] 10.2 Verify all tests pass on main
+- [ ] 10.3 Run full build on main
+- [ ] 10.4 Publish to npm: `npm run release` (from fpkit directory)
+- [ ] 10.5 Verify package published successfully
+- [ ] 10.6 Create GitHub release with changelog
+- [ ] 10.7 Tag release in Git
+- [ ] 10.8 Announce release to users
+- [ ] 10.9 Update documentation site (if applicable)
+- [ ] 10.10 Share migration guide prominently
+- [ ] 10.11 Monitor for issues after release
+- [ ] 10.12 Respond to user questions/issues quickly
+
+## 11. Post-Release
+
+- [ ] 11.1 Monitor npm download stats
+- [ ] 11.2 Watch for GitHub issues related to migration
+- [ ] 11.3 Collect user feedback on new variable names
+- [ ] 11.4 Document lessons learned for future refactoring
+- [ ] 11.5 Plan next phase (remaining components)
+- [ ] 11.6 Update internal documentation with migration metrics
+- [ ] 11.7 Celebrate successful release! 🎉
+
+## Notes
+
+- **Critical**: Do NOT skip testing steps - these are breaking changes
+- **Order Matters**: Complete components sequentially to catch issues early
+- **Git Commits**: Make atomic commits per component for easier rollback if needed
+- **Backup Files**: Keep backups until changes are verified working
+- **Communication**: Keep users informed throughout beta and release process
+
+## Acceptance Criteria
+
+- [ ] All 46 variables renamed according to standard
+- [ ] All tests pass without modification
+- [ ] All components render correctly in Storybook
+- [ ] No visual regressions detected
+- [ ] Migration guide complete and tested
+- [ ] CHANGELOG documents all breaking changes
+- [ ] Beta tested by at least 2 users (if beta release used)
+- [ ] Build succeeds without errors or warnings
+- [ ] Lint passes without errors
+- [ ] Documentation updated with new variable names
+- [ ] Customization examples work as documented
+- [ ] Final release published to npm successfully


### PR DESCRIPTION
Add two OpenSpec change proposals to establish consistent CSS variable naming across the component library:

- establish-css-variable-naming-standard: Documentation-only proposal defining naming conventions, approved abbreviations, and patterns for variants/states
- refactor-core-component-css-variables: Implementation proposal to refactor Button, Form/Input, and Card components (breaking changes)

These proposals aim to improve developer experience by making CSS variable names predictable, improving IDE autocomplete, and reducing the learning curve for library customization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>