### PR TITLE
Release @fpkit/acss v3.9.0

### DIFF
--- a/packages/fpkit/CHANGELOG.md
+++ b/packages/fpkit/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.9.0](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@3.6.0...@fpkit/acss@3.9.0) (2026-01-09)
+
+
+### Bug Fixes
+
+* **columns:** resolve JSX syntax error and enhance responsive docs ([8d04c64](https://github.com/shawn-sandy/fpkit/commit/8d04c64e67ed64d1606f7162283aafa551bad0f1))
+
+
+* feat(checkbox)!: deprecate Checkbox component in favor of Input type="checkbox" ([f16ff10](https://github.com/shawn-sandy/fpkit/commit/f16ff10afe44590c575fafb48dbd0b8832eab70b))
+
+
+### Features
+
+* **checkbox:** add accessible checkbox component with size and color variants ([6aa1b50](https://github.com/shawn-sandy/fpkit/commit/6aa1b50a7d79f24bdcc435faf31312c0f2ecf747))
+* **checkbox:** implement Checkbox wrapper component with modern CSS architecture ([f971fec](https://github.com/shawn-sandy/fpkit/commit/f971fec36ef8c85295f4d38015ec198f37971f48))
+* **title:** add size and color variants with data-title attributes ([e7f9b7a](https://github.com/shawn-sandy/fpkit/commit/e7f9b7a90363fe11d12f7431f185d4297c730c6a))
+* **title:** add size and color variants with data-title attributes ([1e93884](https://github.com/shawn-sandy/fpkit/commit/1e93884becb94e8ae215180ba5adb9660fdbfa7f))
+
+
+### BREAKING CHANGES
+
+* **checkbox:** Standalone Checkbox component deprecated in favor of form/Checkbox wrapper
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+* The standalone Checkbox component is now deprecated and will be removed in a future version.
+
+- Add @deprecated JSDoc tags to CheckboxProps and Checkbox component
+- Add runtime console warning in development mode
+- Add deprecation notices to README.mdx and STYLES.mdx
+- Change Storybook tag from "beta" to "deprecated"
+- Add CSS variables for checkbox styling in form.scss
+- Add checkbox story to Input component demonstrating new pattern
+
+Migration path: Replace <Checkbox /> with <Input type="checkbox" />
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+
+
+
+
+
 # [3.7.0](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@3.6.0...@fpkit/acss@3.7.0) (2026-01-06)
 
 

--- a/packages/fpkit/package-lock.json
+++ b/packages/fpkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fpkit/acss",
-  "version": "3.7.0",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fpkit/acss",
-      "version": "3.7.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -126,5 +126,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "1049811ad793c7a3b0bb37c3d7abdbf171e0a9eb"
+  "gitHead": "87b188279548219c8d93538b58504077aef71a71"
 }

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -2,7 +2,7 @@
   "name": "@fpkit/acss",
   "description": "A lightweight React UI library for building modern and accessible components that leverage CSS custom properties for reactive Styles.",
   "private": false,
-  "version": "3.7.0",
+  "version": "3.9.0",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.0.0"

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import './button.css';
 
 export interface ButtonProps {

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from './Button';
 import './header.css';
 


### PR DESCRIPTION
## Release Summary

Published **@fpkit/acss v3.9.0** to npm registry.

## Changes Since 3.8.0

### Features
- **feat(checkbox)**: Implement Checkbox wrapper component with modern CSS architecture (f971fec)
- **feat(checkbox)!**: Deprecate Checkbox component in favor of Input type="checkbox" (f16ff10)

### Improvements
- **refactor(form)**: Optimize input styles by reducing selector duplication (da2d0d9)

### Maintenance
- **chore**: Remove unused React imports from Storybook stories (b65c6d1)
- **chore(fpkit)**: Update gitHead after publish (dfd0374)

## Package Info

- **Package**: @fpkit/acss
- **Version**: 3.9.0
- **Published**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
- **Registry**: https://www.npmjs.com/package/@fpkit/acss

## Verification

\`\`\`bash
npm view @fpkit/acss version
# Output: 3.9.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes `@fpkit/acss` v3.9.0 with a breaking deprecation of the standalone `Checkbox` in favor of `<Input type="checkbox" />`, plus new checkbox variants and related docs.
> 
> - Update `CHANGELOG.md` with 3.9.0 notes, including breaking change and checkbox features
> - Bump package versions in `package.json` and `package-lock.json`; update `gitHead`
> - Storybook maintenance: remove unused `React` imports in `src/stories/Button.tsx` and `src/stories/Header.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfd0374e030806ae870ff67cb67f04c750f58398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->