### PR TITLE
fix(plugins/fpkit-developer): remove invalid manifest fields

### DIFF
--- a/.claude/plugins/fpkit-developer/.claude-plugin/plugin.json
+++ b/.claude/plugins/fpkit-developer/.claude-plugin/plugin.json
@@ -6,11 +6,5 @@
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"
   },
-  "license": "MIT",
-  "skills": [
-    "skills/fpkit-developer"
-  ],
-  "commands": [
-    "commands/fpkit-dev.md"
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Removed `skills` and `commands` arrays from `plugin.json` manifest
- These fields are not part of the valid Claude Code plugin schema

## Changes
Claude Code's plugin validator (Zod-based) rejects unknown fields in `plugin.json`. The `skills` and `commands` arrays caused installation to fail with "Invalid input" errors. Skills and commands are auto-discovered by convention from their respective directories, so declaring them in the manifest is unnecessary and invalid.