### PR TITLE
chore(release): publish @fpkit/acss@6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to @fpkit/acss will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.4.1] - 2026-03-06
+
+### Fixed
+
+- **DialogModal missing export** — `DialogModal` was implemented in v6.4.0 but accidentally omitted from the package's public exports in `index.ts`. Consumers can now import it directly: `import { DialogModal } from '@fpkit/acss'`
+
+---
+
 ## [6.4.0] - 2026-03-06
 
 ### Added

--- a/docs/planning/release-v6.4.1-dialog-modal-export.md
+++ b/docs/planning/release-v6.4.1-dialog-modal-export.md
@@ -1,0 +1,103 @@
+# Release Plan: @fpkit/acss v6.4.1
+
+## Context
+
+`DialogModal` was developed and included in v6.4.0 internally, but its public export was accidentally omitted from `packages/fpkit/src/index.ts`. This patch release adds that missing export so consumers can import `DialogModal` directly from `@fpkit/acss`.
+
+**Change:** Add `export { DialogModal }` to `packages/fpkit/src/index.ts`
+**Bump type:** Patch (`6.4.0` → `6.4.1`)
+
+---
+
+## Pre-flight Status
+
+| Check | Status |
+|-------|--------|
+| Branch | `main` (clean, up to date) |
+| Node | v24.10.0 (OK) |
+| npm | 11.6.0 (OK) |
+| npm auth | NOT LOGGED IN — must run `npm login` before Step 8 |
+| Uncommitted change | `packages/fpkit/src/index.ts` — must commit to main first |
+| Local version | 6.4.0 |
+| npm registry version | 6.4.0 |
+
+---
+
+## Steps
+
+1. **Commit the export fix to main**
+   - Stage and commit `packages/fpkit/src/index.ts`
+   - Message: `fix(dialog): export DialogModal from package index`
+
+2. **Validate: build, lint, test**
+   ```bash
+   cd packages/fpkit
+   npm run build && npm run lint && npm test
+   cd ../..
+   ```
+
+3. **Create release branch**
+   ```bash
+   git checkout -b release/v6.4.1
+   ```
+
+4. **Bump version with Lerna**
+   ```bash
+   lerna version patch --no-push --no-git-tag-version
+   ```
+   - Updates `packages/fpkit/package.json` version to `6.4.1`
+
+5. **Update CHANGELOG.md**
+   - Add entry for `6.4.1` documenting the `DialogModal` export fix
+
+6. **Commit version + changelog**
+   ```bash
+   git add packages/fpkit/package.json CHANGELOG.md
+   git commit -m "chore(release): publish @fpkit/acss@6.4.1"
+   ```
+
+7. **Push branch and open PR**
+   ```bash
+   git push -u origin release/v6.4.1
+   gh pr create --title "chore(release): publish @fpkit/acss@6.4.1" \
+     --body "Patch release: exports DialogModal from package public API."
+   ```
+
+8. **After PR merge — publish**
+   ```bash
+   npm login   # Enter credentials + OTP
+   git checkout main && git pull
+   lerna publish from-package --yes --otp={6-digit-code}
+   git push --follow-tags
+   ```
+
+9. **Cleanup**
+   ```bash
+   git branch -d release/v6.4.1
+   git push origin --delete release/v6.4.1
+   ```
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `packages/fpkit/src/index.ts` | Add `export { DialogModal }` (already staged) |
+| `packages/fpkit/package.json` | Version bump `6.4.0` → `6.4.1` (via Lerna) |
+| `CHANGELOG.md` | Add `6.4.1` release notes |
+
+---
+
+## Verification
+
+- After publish: `npm view @fpkit/acss version` should return `6.4.1`
+- Install in a test project: `npm install @fpkit/acss@6.4.1`
+- Verify import works: `import { DialogModal } from '@fpkit/acss'`
+- Confirm Storybook still runs: `npm start` at repo root
+
+---
+
+## Unresolved Questions
+
+None.

--- a/packages/fpkit/CHANGELOG.md
+++ b/packages/fpkit/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.4.1](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.4.1) (2026-03-07)
+
+
+### Bug Fixes
+
+* **dialog:** export DialogModal from package index ([269a245](https://github.com/shawn-sandy/fpkit/commit/269a245ffa1f1f5922427a07eb8c5c0219b57a8b))
+
+
+
+
+
 # [6.4.0](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.3.0...@fpkit/acss@6.4.0) (2026-03-06)
 
 

--- a/packages/fpkit/package-lock.json
+++ b/packages/fpkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fpkit/acss",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fpkit/acss",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -2,7 +2,7 @@
   "name": "@fpkit/acss",
   "description": "A lightweight React UI library for building modern and accessible components that leverage CSS custom properties for reactive Styles.",
   "private": false,
-  "version": "6.4.0",
+  "version": "6.4.1",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.0.0"

--- a/packages/fpkit/src/index.ts
+++ b/packages/fpkit/src/index.ts
@@ -53,7 +53,10 @@
  * ```
  */
 export { Button, type ButtonProps } from "./components/buttons/button";
-export { IconButton, type IconButtonProps } from "./components/buttons/icon-button";
+export {
+  IconButton,
+  type IconButtonProps,
+} from "./components/buttons/icon-button";
 export {
   Card,
   Title as CardTitle,
@@ -85,6 +88,7 @@ export { Modal, type ModalProps } from "./components/modal/modal";
 export { Popover, type PopoverProps } from "./components/popover/popover";
 export { RenderTable as TBL, type TableProps } from "./components/tables/table";
 export { Dialog } from "./components/dialog/dialog";
+export { DialogModal } from "./components/dialog/dialog-modal";
 export { TextToSpeech } from "./components/text-to-speech/TextToSpeech";
 
 /**


### PR DESCRIPTION
## Summary

- Adds missing `DialogModal` export to package public API (`index.ts`)
- `DialogModal` was developed and shipped internally in v6.4.0 but the named export was accidentally omitted
- Consumers can now import: `import { DialogModal } from '@fpkit/acss'`

## Changes

| File | Change |
|------|--------|
| `packages/fpkit/src/index.ts` | Add `export { DialogModal }` |
| `packages/fpkit/package.json` | Version bump `6.4.0` → `6.4.1` |
| `CHANGELOG.md` | Add `6.4.1` release notes |

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint passes — 0 errors, 2 pre-existing warnings
- [x] All 991 tests pass (`npm test`)
- [ ] After merge: verify `npm view @fpkit/acss version` returns `6.4.1`
- [ ] After merge: confirm `import { DialogModal } from '@fpkit/acss'` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)