### PR TITLE
feat(dialog): export DialogProps and DialogModalProps types

### DIFF
--- a/docs/planning/export-dialog-types-and-publish.md
+++ b/docs/planning/export-dialog-types-and-publish.md
@@ -1,0 +1,36 @@
+# Export Dialog Types and Publish
+
+## Context
+
+`DialogModal` and `Dialog` are exported from `packages/fpkit/src/index.ts` but their TypeScript types (`DialogModalProps`, `DialogProps`) are not. Every other component in the library follows the pattern of co-exporting its props type (e.g., `export { Button, type ButtonProps }`). Consumers currently cannot import these types without reaching into internal paths.
+
+## Changes
+
+### 1. Add type exports to `packages/fpkit/src/index.ts`
+
+Add a type export line for dialog types from `./components/dialog/dialog.types`:
+
+```ts
+// Line 90-91 (current)
+export { Dialog } from "./components/dialog/dialog";
+export { DialogModal } from "./components/dialog/dialog-modal";
+
+// Add after line 91:
+export type { DialogProps, DialogModalProps } from "./components/dialog/dialog.types";
+```
+
+### 2. Build and test
+
+- Run `npm run build` in `packages/fpkit/`
+- Run `npm test` in `packages/fpkit/`
+
+### 3. Publish to npm
+
+- Use the `npm-monorepo-publish` skill
+- This is a patch-level fix (type export addition, no runtime changes)
+
+## Verification
+
+1. Confirm types appear in `libs/` build output `.d.ts` files
+2. Tests pass
+3. Package published successfully

--- a/docs/planning/imperative-zooming-galaxy.md
+++ b/docs/planning/imperative-zooming-galaxy.md
@@ -1,0 +1,38 @@
+# Export Dialog Types and Publish to npm
+
+## Context
+
+`Dialog` and `DialogModal` are exported from `packages/fpkit/src/index.ts` (lines 90-91) but their TypeScript types (`DialogProps`, `DialogModalProps`) are **not** re-exported. Every other component follows the pattern of co-exporting props types (e.g., `export { Button, type ButtonProps }`). This forces consumers to use deep imports for the types, which is incorrect for a published package.
+
+## Changes
+
+### 1. Update `packages/fpkit/src/index.ts` (lines 90-92)
+
+Add type exports from `./components/dialog/dialog.types`:
+
+```ts
+// Current (lines 90-91):
+export { Dialog } from "./components/dialog/dialog";
+export { DialogModal } from "./components/dialog/dialog-modal";
+
+// After:
+export { Dialog } from "./components/dialog/dialog";
+export { DialogModal } from "./components/dialog/dialog-modal";
+export type { DialogProps, DialogModalProps } from "./components/dialog/dialog.types";
+```
+
+### 2. Build and test (`packages/fpkit/`)
+
+- `npm run build` — confirm `.d.ts` output includes the new type exports
+- `npm test` — all tests pass
+
+### 3. Publish patch to npm
+
+- Use the `npm-monorepo-publish` skill
+- Version bump: **patch** (type export only, no runtime change)
+
+## Verification
+
+1. After build, grep `libs/` for `DialogModalProps` and `DialogProps` in `.d.ts` files
+2. All existing tests pass
+3. Package published to npm

--- a/docs/planning/indexed-floating-pine.md
+++ b/docs/planning/indexed-floating-pine.md
@@ -1,0 +1,26 @@
+# Export Dialog Types and Publish
+
+## Context
+
+`Dialog` and `DialogModal` are exported from `packages/fpkit/src/index.ts` but their TypeScript types (`DialogProps`, `DialogModalProps`) are not. All other components co-export their props types. Consumers cannot import dialog types without reaching into internal paths.
+
+## Steps
+
+1. **Add type exports** to `packages/fpkit/src/index.ts` after line 91:
+   ```ts
+   export type { DialogProps, DialogModalProps } from "./components/dialog/dialog.types";
+   ```
+   - File: `packages/fpkit/src/index.ts` (lines 90-91 — current dialog exports)
+   - Types source: `packages/fpkit/src/components/dialog/dialog.types.ts`
+
+2. **Build** — run `npm run build` in `packages/fpkit/`
+
+3. **Test** — run `npm test` in `packages/fpkit/`
+
+4. **Publish** — use the `npm-monorepo-publish` skill (patch-level bump, no runtime changes)
+
+## Verification
+
+- `libs/` build output `.d.ts` files include `DialogProps` and `DialogModalProps`
+- All tests pass
+- Package published to npm successfully

--- a/packages/fpkit/src/index.ts
+++ b/packages/fpkit/src/index.ts
@@ -89,6 +89,7 @@ export { Popover, type PopoverProps } from "./components/popover/popover";
 export { RenderTable as TBL, type TableProps } from "./components/tables/table";
 export { Dialog } from "./components/dialog/dialog";
 export { DialogModal } from "./components/dialog/dialog-modal";
+export type { DialogProps, DialogModalProps } from "./components/dialog/dialog.types";
 export { TextToSpeech } from "./components/text-to-speech/TextToSpeech";
 
 /**


### PR DESCRIPTION
## Summary

- Adds `export type { DialogProps, DialogModalProps }` to `packages/fpkit/src/index.ts`
- Follows the co-export pattern used by all other components (e.g. `Button`/`ButtonProps`, `Popover`/`PopoverProps`)
- Consumers can now import dialog types directly: `import type { DialogProps } from '@fpkit/acss'`

## Type of change

- Patch — type-only export, no runtime changes

## Test plan

- [x] Build succeeds (`npm run package` — ESM, CJS, DTS all generated)
- [x] All 991 tests pass
- [x] `DialogProps` and `DialogModalProps` confirmed in `libs/index.d.ts` and `libs/dialog-*.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)