### PR TITLE
chore(release): publish @fpkit/acss@6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to @fpkit/acss will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.4.2] - 2026-03-07
+
+### Added
+
+- **Dialog type exports** — `DialogProps` and `DialogModalProps` are now exported from the package index. Consumers can import them directly: `import type { DialogProps, DialogModalProps } from '@fpkit/acss'`
+
+---
+
 ## [6.4.1] - 2026-03-06
 
 ### Fixed

--- a/packages/fpkit/CHANGELOG.md
+++ b/packages/fpkit/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.4.2](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.4.2) (2026-03-07)
+
+
+### Bug Fixes
+
+* **dialog:** export DialogModal from package index ([269a245](https://github.com/shawn-sandy/fpkit/commit/269a245ffa1f1f5922427a07eb8c5c0219b57a8b))
+
+
+### Features
+
+* **dialog:** export DialogProps and DialogModalProps types from package index ([434c0cf](https://github.com/shawn-sandy/fpkit/commit/434c0cf9d41eda837878747ea965339df35e1025))
+
+
+
+
+
 ## [6.4.1](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.4.1) (2026-03-07)
 
 

--- a/packages/fpkit/package-lock.json
+++ b/packages/fpkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fpkit/acss",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fpkit/acss",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -2,7 +2,7 @@
   "name": "@fpkit/acss",
   "description": "A lightweight React UI library for building modern and accessible components that leverage CSS custom properties for reactive Styles.",
   "private": false,
-  "version": "6.4.1",
+  "version": "6.4.2",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.0.0"
@@ -123,5 +123,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "267091cf42709bbb5e74aa9b1d75bc2ced157b04"
+  "gitHead": "5685f0cbe7cf2b67cd46f69b55b14c49cc6f70a7"
 }


### PR DESCRIPTION
## Summary

- Patch release: `6.4.1` → `6.4.2`
- Exports `DialogProps` and `DialogModalProps` types from package index
- No runtime changes — type-only addition

## Changes

- `packages/fpkit/package.json` — version bumped to 6.4.2
- `CHANGELOG.md` — release notes added

## Test plan

- [x] Build succeeded (ESM, CJS, DTS)
- [x] All 991 tests pass
- [x] Types confirmed in `libs/index.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)