### PR TITLE
chore(release): publish @fpkit/acss@6.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to @fpkit/acss will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.4.3] - 2026-03-07
+
+### Fixed
+
+- **Dialog type export formatting** — Corrected export format for `DialogProps` and `DialogModalProps` in the package index for proper type resolution by consumers.
+
+---
+
 ## [6.4.2] - 2026-03-07
 
 ### Added

--- a/docs/planning/publish-v6.4.3.md
+++ b/docs/planning/publish-v6.4.3.md
@@ -1,0 +1,96 @@
+# Publish @fpkit/acss v6.4.3
+
+## Context
+
+Branch `chore/publish-modal` has 2 commits ahead of `main` since the v6.4.2 release:
+- `fix(dialog)`: format export of DialogProps and DialogModalProps types
+- `chore(package)`: update gitHead in package.json
+
+Files changed: `packages/fpkit/package.json`, `packages/fpkit/src/index.ts`
+
+These changes need to be merged to `main` before publishing. The fix commit warrants a **patch** bump: `6.4.2 → 6.4.3`.
+
+---
+
+## Plan
+
+### Phase 1: Pre-flight validation
+
+1. Confirm npm auth: `npm whoami` (expected: `shawnsandy`)
+2. Confirm Node >= 22.12.0 and npm >= 8.0.0
+3. Confirm `@fpkit/acss@6.4.3` does not already exist on npm registry
+
+### Phase 2: Merge chore/publish-modal → main
+
+4. Push `chore/publish-modal` to remote (already up to date)
+5. Create PR: `chore/publish-modal → main`
+   - Title: `fix(dialog): format export of DialogProps and DialogModalProps types`
+6. Merge the PR after review
+
+### Phase 3: Build & validate on main
+
+7. Switch to `main` and pull latest
+8. In `packages/fpkit/`, run sequentially:
+   - `npm run build`
+   - `npm run lint`
+   - `npm test`
+9. All must exit 0 before proceeding
+
+### Phase 4: Create release branch
+
+10. Create branch: `release/v6.4.3` from `main`
+11. Run: `lerna version patch --no-push --no-git-tag-version`
+    - Updates `packages/fpkit/package.json` version to `6.4.3`
+
+### Phase 5: Update CHANGELOG
+
+12. Add entry at top of `CHANGELOG.md`:
+
+```
+## [6.4.3] - 2026-03-07
+
+### Fixed
+
+- **Dialog type export formatting** — Corrected export format for `DialogProps`
+  and `DialogModalProps` in the package index for proper type resolution.
+```
+
+13. Commit both changes:
+    - Message: `chore(release): publish @fpkit/acss@6.4.3`
+
+### Phase 6: PR review
+
+14. Push `release/v6.4.3` to remote
+15. Create PR: `release/v6.4.3 → main`
+    - Title: `chore(release): publish @fpkit/acss@6.4.3`
+16. Merge after review
+
+### Phase 7: Publish to npm
+
+17. Switch to `main` and pull latest
+18. Request fresh OTP from authenticator app
+19. Run: `lerna publish from-package --yes --otp={6-digit-code}`
+20. Run: `git push --follow-tags`
+
+### Phase 8: Cleanup
+
+21. Delete release branch locally and remotely:
+    - `git branch -d release/v6.4.3`
+    - `git push origin --delete release/v6.4.3`
+22. Verify on npm: `npm view @fpkit/acss version` (should return `6.4.3`)
+
+---
+
+## Key Files
+
+- `packages/fpkit/package.json` — version field updated by Lerna (Step 11)
+- `CHANGELOG.md` — release notes added (Step 12)
+- `packages/fpkit/src/index.ts` — already updated on `chore/publish-modal`
+
+---
+
+## Verification
+
+- `npm view @fpkit/acss version` returns `6.4.3`
+- `npm view @fpkit/acss@6.4.3` shows correct metadata
+- GitHub shows merged release PR and new tag `v6.4.3`

--- a/packages/fpkit/CHANGELOG.md
+++ b/packages/fpkit/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.4.3](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.4.3) (2026-03-07)
+
+
+### Bug Fixes
+
+* **dialog:** export DialogModal from package index ([269a245](https://github.com/shawn-sandy/fpkit/commit/269a245ffa1f1f5922427a07eb8c5c0219b57a8b))
+* **dialog:** format export of DialogProps and DialogModalProps types ([94d6898](https://github.com/shawn-sandy/fpkit/commit/94d689856d51b6b01e069a965b69e7c407f84760))
+
+
+### Features
+
+* **dialog:** export DialogProps and DialogModalProps types from package index ([434c0cf](https://github.com/shawn-sandy/fpkit/commit/434c0cf9d41eda837878747ea965339df35e1025))
+
+
+
+
+
 ## [6.4.2](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.4.2) (2026-03-07)
 
 

--- a/packages/fpkit/package-lock.json
+++ b/packages/fpkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fpkit/acss",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fpkit/acss",
-      "version": "6.4.2",
+      "version": "6.4.3",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -2,7 +2,7 @@
   "name": "@fpkit/acss",
   "description": "A lightweight React UI library for building modern and accessible components that leverage CSS custom properties for reactive Styles.",
   "private": false,
-  "version": "6.4.2",
+  "version": "6.4.3",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.0.0"


### PR DESCRIPTION
## Release: @fpkit/acss v6.4.3

### Changes

- **Dialog type export formatting** — Corrected export format for `DialogProps` and `DialogModalProps` in the package index for proper type resolution by consumers.

### Checklist

- [x] Build passes (`npm run build`)
- [x] Lint passes (0 errors, 2 pre-existing warnings)
- [x] All 991 tests pass across 25 test files
- [x] CHANGELOG.md updated
- [x] Version bumped: `6.4.2 → 6.4.3`

### After merge

Run `lerna publish from-package --yes --otp={code}` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)