### PR TITLE
chore(package): update gitHead after v6.4.3 publish

### DIFF
--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -123,5 +123,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "e0e6e8a0bd3931cd33bfcabcab7f25f276bfe0bf"
+  "gitHead": "227a0a8c658f1361c73752f47a2eb5e3ceb38a2c"
 }

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -123,5 +123,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "227a0a8c658f1361c73752f47a2eb5e3ceb38a2c"
+  "gitHead": "5be757c113749ec092f560059c4c15c9dbe05d94"
 }


### PR DESCRIPTION
## Post-publish cleanup

Updates `gitHead` in `packages/fpkit/package.json` to reflect the current HEAD after the v6.4.3 release publish.

This is a routine post-publish cleanup — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)