### PR TITLE
refactor(dialog): replace close Button with IconButton

### DIFF
--- a/docs/planning/tidy-honking-yao.md
+++ b/docs/planning/tidy-honking-yao.md
@@ -1,0 +1,77 @@
+# Replace Dialog Close Button with IconButton + Configurable Icon Size
+
+## Context
+
+The dialog header's close button uses a generic `Button` with `data-btn="icon"` and a hardcoded `Icon.Remove` at size `16`. The user wants to:
+1. Replace it with the library's own `IconButton` component
+2. Make the close icon size configurable via a prop, defaulting to `24`
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `packages/fpkit/src/components/dialog/dialog.types.ts` | Add `closeIconSize` to `BaseDialogProps` and `DialogHeaderProps` |
+| `packages/fpkit/src/components/dialog/views/dialog-header.tsx` | Swap `Button` for `IconButton`, use `closeIconSize` prop |
+| `packages/fpkit/src/components/dialog/dialog.tsx` | Forward `closeIconSize` to `DialogHeader` |
+| `packages/fpkit/src/components/dialog/dialog-modal.tsx` | Forward `closeIconSize` to `Dialog` |
+
+## Steps
+
+### 1. Add `closeIconSize` prop to types
+
+**File:** `packages/fpkit/src/components/dialog/dialog.types.ts`
+
+- Add to `BaseDialogProps`:
+  ```ts
+  /** Size of the close button icon in pixels. @default 24 */
+  closeIconSize?: number;
+  ```
+- Add to `DialogHeaderProps`:
+  ```ts
+  /** Size of the close button icon in pixels. @default 24 */
+  closeIconSize?: number;
+  ```
+
+### 2. Replace `Button` with `IconButton` in dialog-header
+
+**File:** `packages/fpkit/src/components/dialog/views/dialog-header.tsx`
+
+- Replace `Button` import with `IconButton` from `#components/buttons/icon-button`
+- Accept `closeIconSize = 24` in destructured props
+- Replace the `<Button>` JSX with:
+  ```tsx
+  <IconButton
+    type="button"
+    onClick={handleClose}
+    className="dialog-close"
+    aria-label="Close dialog"
+    icon={
+      <Icon>
+        <Icon.Remove size={closeIconSize} />
+      </Icon>
+    }
+  />
+  ```
+
+### 3. Forward `closeIconSize` in `Dialog`
+
+**File:** `packages/fpkit/src/components/dialog/dialog.tsx`
+
+- Destructure `closeIconSize` from props
+- Pass to `<DialogHeader closeIconSize={closeIconSize} />`
+
+### 4. Forward `closeIconSize` in `DialogModal`
+
+**File:** `packages/fpkit/src/components/dialog/dialog-modal.tsx`
+
+- Destructure `closeIconSize` from props
+- Pass to `<Dialog closeIconSize={closeIconSize} />`
+
+### 5. Run tests
+
+No test changes expected — existing tests query by role/accessible name which remain unchanged.
+
+## Verification
+
+1. `cd packages/fpkit && npm test -- --run src/components/dialog/dialog.test.tsx`
+2. `npm start` (Storybook) — visually confirm the close icon renders at the new default size (24px) and that custom sizes work

--- a/packages/fpkit/src/components/dialog/dialog-modal.tsx
+++ b/packages/fpkit/src/components/dialog/dialog-modal.tsx
@@ -83,6 +83,7 @@ export const DialogModal: React.FC<DialogModalProps> = ({
   icon,
   size,
   position,
+  closeIconSize,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const lastFocusedElement = useRef<HTMLElement | null>(null);
@@ -154,6 +155,7 @@ export const DialogModal: React.FC<DialogModalProps> = ({
         hideFooter={hideFooter}
         size={size}
         position={position}
+        closeIconSize={closeIconSize}
       >
         {children}
       </Dialog>

--- a/packages/fpkit/src/components/dialog/dialog.tsx
+++ b/packages/fpkit/src/components/dialog/dialog.tsx
@@ -48,6 +48,7 @@ import type { DialogProps } from "./dialog.types";
  * @param {string} [props.className] - Additional CSS classes to apply
  * @param {string} [props.dialogLabel] - Optional aria-label for the dialog
  * @param {CSSProperties} [props.styles] - Inline styles to apply to dialog element
+ * @param {number} [props.closeIconSize=24] - Size of the close icon in pixels
  * @returns {JSX.Element} A controlled dialog component
  */
 export const Dialog: React.FC<DialogProps> = ({

--- a/packages/fpkit/src/components/dialog/dialog.tsx
+++ b/packages/fpkit/src/components/dialog/dialog.tsx
@@ -66,6 +66,7 @@ export const Dialog: React.FC<DialogProps> = ({
   styles,
   size,
   position = "center",
+  closeIconSize,
 }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
@@ -116,7 +117,7 @@ export const Dialog: React.FC<DialogProps> = ({
       {...(size && { "data-size": size })}
       {...(position && { "data-position": position })}
     >
-      <DialogHeader dialogTitle={dialogTitle} onClick={handleClose} id={titleId} />
+      <DialogHeader dialogTitle={dialogTitle} onClick={handleClose} id={titleId} closeIconSize={closeIconSize} />
 
       <UI
         as="section"

--- a/packages/fpkit/src/components/dialog/dialog.types.ts
+++ b/packages/fpkit/src/components/dialog/dialog.types.ts
@@ -41,6 +41,8 @@ export interface BaseDialogProps {
   size?: DialogSize;
   /** Position of the dialog on screen (center, top, bottom, left, right, corners) */
   position?: DialogPosition;
+  /** Size of the close button icon in pixels. @default 24 */
+  closeIconSize?: number;
 }
 
 /**
@@ -139,6 +141,8 @@ export interface DialogHeaderProps {
   id?: string;
   /** Heading level for the title */
   type?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  /** Size of the close button icon in pixels. @default 24 */
+  closeIconSize?: number;
 }
 
 /**

--- a/packages/fpkit/src/components/dialog/views/dialog-header.tsx
+++ b/packages/fpkit/src/components/dialog/views/dialog-header.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import UI from "#components/ui";
 import Heading from "#components/heading/heading";
-import Button from "#components/buttons/button";
+import { IconButton } from "#components/buttons/icon-button";
 import Icon from "#components/icons/icon";
 import type { DialogHeaderProps } from "../dialog.types";
 
@@ -37,6 +37,7 @@ const DialogHeader: React.FC<DialogHeaderProps> = ({
   onClick,
   id,
   type = "h3",
+  closeIconSize = 24,
 }) => {
   const handleClose = useCallback(() => {
     onClick();
@@ -47,17 +48,17 @@ const DialogHeader: React.FC<DialogHeaderProps> = ({
       <Heading type={type} className="dialog-title" id={id}>
         {dialogTitle || "Dialog"}
       </Heading>
-      <Button
+      <IconButton
         type="button"
         onClick={handleClose}
         className="dialog-close"
         aria-label="Close dialog"
-        data-btn="icon"
-      >
-        <Icon>
-          <Icon.Remove size={16} />
-        </Icon>
-      </Button>
+        icon={
+          <Icon>
+            <Icon.Remove size={closeIconSize} />
+          </Icon>
+        }
+      />
     </UI>
   );
 };

--- a/packages/fpkit/src/components/dialog/views/dialog-header.tsx
+++ b/packages/fpkit/src/components/dialog/views/dialog-header.tsx
@@ -20,6 +20,7 @@ import type { DialogHeaderProps } from "../dialog.types";
  * @param {() => void} props.onClick - Callback function triggered when close button is clicked
  * @param {string} [props.id] - Optional ID for aria-labelledby linking. Auto-generated if not provided.
  * @param {"h1" | "h2" | "h3" | "h4" | "h5" | "h6"} [props.type="h3"] - Heading level for semantic structure
+ * @param {number} [props.closeIconSize=24] - Size of the close icon in pixels
  * @returns {JSX.Element} A dialog header with title and close button
  *
  * @example


### PR DESCRIPTION
## Changes

- Replace generic `Button` with `IconButton` in dialog header's close button
- Add `closeIconSize` prop to `BaseDialogProps` and `DialogHeaderProps` (defaults to 24px)
- Update icon size from hardcoded 16px to configurable `closeIconSize`
- Forward `closeIconSize` through `Dialog` and `DialogModal` components
- Add planning documentation

## Files Modified

- `dialog.types.ts` - Add `closeIconSize` prop to types
- `dialog-header.tsx` - Swap `Button` for `IconButton`, use configurable icon size
- `dialog.tsx` - Forward `closeIconSize` to `DialogHeader`
- `dialog-modal.tsx` - Forward `closeIconSize` to `Dialog`
- `tidy-honking-yao.md` - Add planning documentation