### PR TITLE
fix(dialog): ensure modal centers by default with fit-content

### DIFF
--- a/packages/fpkit/src/components/dialog/dialog.scss
+++ b/packages/fpkit/src/components/dialog/dialog.scss
@@ -3,6 +3,8 @@
   --dialog-width: var(--dialog-min-width);
   --dialog-max-width: 90vw;
   --dialog-max-height: 85vh;
+  --dialog-margin: auto;
+  --dialog-inset: 0;
   --dialog-gap: 0.625rem;
   --dialog-border-color: var(--color-border);
   --dialog-border-width: thin;
@@ -36,6 +38,8 @@
 }
 
 dialog {
+  margin: var(--dialog-margin);
+  inset: var(--dialog-inset);
   width: var(--dialog-width);
   max-width: var(--dialog-max-width);
   max-height: var(--dialog-max-height);
@@ -159,52 +163,52 @@ dialog[data-size="full"] {
 /* ── Position variants ─────────────────────── */
 
 dialog[data-position="center"] {
-  margin: auto;
-  inset: 0;
+  --dialog-margin: auto;
+  --dialog-inset: 0;
 }
 
 dialog[data-position="top"] {
-  margin: 0 auto auto auto;
-  inset: 0;
+  --dialog-margin: 0 auto auto auto;
+  --dialog-inset: 0;
 }
 
 dialog[data-position="bottom"] {
-  margin: auto auto 0 auto;
-  inset: 0;
+  --dialog-margin: auto auto 0 auto;
+  --dialog-inset: 0;
 }
 
 dialog[data-position="left"] {
-  margin: 0 auto 0 0;
-  inset: 0;
+  --dialog-margin: 0 auto 0 0;
+  --dialog-inset: 0;
   height: 100vh;
   max-height: 100vh;
   border-radius: 0;
 }
 
 dialog[data-position="right"] {
-  margin: 0 0 0 auto;
-  inset: 0;
+  --dialog-margin: 0 0 0 auto;
+  --dialog-inset: 0;
   height: 100vh;
   max-height: 100vh;
   border-radius: 0;
 }
 
 dialog[data-position="top-left"] {
-  margin: 0 auto auto 0;
-  inset: 0;
+  --dialog-margin: 0 auto auto 0;
+  --dialog-inset: 0;
 }
 
 dialog[data-position="top-right"] {
-  margin: 0 0 auto auto;
-  inset: 0;
+  --dialog-margin: 0 0 auto auto;
+  --dialog-inset: 0;
 }
 
 dialog[data-position="bottom-left"] {
-  margin: auto auto 0 0;
-  inset: 0;
+  --dialog-margin: auto auto 0 0;
+  --dialog-inset: 0;
 }
 
 dialog[data-position="bottom-right"] {
-  margin: auto 0 0 auto;
-  inset: 0;
+  --dialog-margin: auto 0 0 auto;
+  --dialog-inset: 0;
 }

--- a/packages/fpkit/src/styles/dialog/dialog.css
+++ b/packages/fpkit/src/styles/dialog/dialog.css
@@ -3,10 +3,10 @@
   --dialog-min-width: max(20rem, 80%);
   --dialog-width: var(--dialog-min-width);
   --dialog-max-width: 90vw;
-  --dialog-height: auto;
+  --dialog-height: fit-content;
   --dialog-max-height: 85vh;
   --dialog-margin: auto;
-  --dialog-inset: unset;
+  --dialog-inset: 0;
   --dialog-gap: 0.625rem;
   --dialog-border-color: var(--color-border);
   --dialog-border-width: thin;
@@ -152,6 +152,7 @@ dialog[data-size=full] {
 /* ── Position variants ─────────────────────── */
 dialog[data-position=center] {
   --dialog-margin: auto;
+  --dialog-inset: 0;
 }
 
 dialog[data-position=top] {

--- a/packages/fpkit/src/styles/index.css
+++ b/packages/fpkit/src/styles/index.css
@@ -2635,10 +2635,10 @@ fieldset[data-fieldset=grouped] > legend {
   --dialog-min-width: max(20rem, 80%);
   --dialog-width: var(--dialog-min-width);
   --dialog-max-width: 90vw;
-  --dialog-height: auto;
+  --dialog-height: fit-content;
   --dialog-max-height: 85vh;
   --dialog-margin: auto;
-  --dialog-inset: unset;
+  --dialog-inset: 0;
   --dialog-gap: 0.625rem;
   --dialog-border-color: var(--color-border);
   --dialog-border-width: thin;
@@ -2784,6 +2784,7 @@ dialog[data-size=full] {
 /* ── Position variants ─────────────────────── */
 dialog[data-position=center] {
   --dialog-margin: auto;
+  --dialog-inset: 0;
 }
 
 dialog[data-position=top] {


### PR DESCRIPTION
## Changes

- Changed `--dialog-height` from `auto` to `fit-content` for proper sizing
- Changed `--dialog-inset` from `unset` to `0` to enable centering
- Added `margin` and `inset` CSS properties to base `dialog` element using CSS variables
- Refactored position variants to use CSS custom properties instead of direct styles
- Ensures dialogs center properly by default while maintaining position flexibility

## Files Modified

- `packages/fpkit/src/components/dialog/dialog.scss`
- `packages/fpkit/src/styles/dialog/dialog.css`
- `packages/fpkit/src/styles/index.css`