### PR TITLE
chore(release): publish @fpkit/acss@6.5.0

### DIFF
--- a/apps/astro-builds/CHANGELOG.md
+++ b/apps/astro-builds/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0](https://github.com/shawn-sandy/acss/compare/astro-fpkit@1.2.2...astro-fpkit@1.3.0) (2026-03-08)
+
+
+### Features
+
+* **dialog:** add size and position props for modal sizing and placement ([33d5cde](https://github.com/shawn-sandy/acss/commit/33d5cde587a9cf15db6e80f288dae928bd9a858e))
+
+
+
+
+
 ## [1.2.2](https://github.com/shawn-sandy/acss/compare/astro-fpkit@1.2.1...astro-fpkit@1.2.2) (2025-12-04)
 
 **Note:** Version bump only for package astro-fpkit

--- a/apps/astro-builds/package-lock.json
+++ b/apps/astro-builds/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "astro-fpkit",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-fpkit",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "dependencies": {
         "@astrojs/react": "^4.1.2",
-        "@fpkit/acss": "^6.4.3",
+        "@fpkit/acss": "^6.5.0",
         "astro": "^5.1.1"
       }
     },

--- a/apps/astro-builds/package.json
+++ b/apps/astro-builds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-fpkit",
   "type": "module",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^4.1.2",
-    "@fpkit/acss": "^6.4.3",
+    "@fpkit/acss": "^6.5.0",
     "astro": "^5.1.1"
   }
 }

--- a/docs/planning/whimsical-napping-clarke.md
+++ b/docs/planning/whimsical-napping-clarke.md
@@ -1,0 +1,55 @@
+# Publish @fpkit/acss@6.5.0
+
+## Context
+
+Dialog component received significant updates since v6.4.3: size/position props, IconButton refactor, centering fixes, and layout/full-size variant styles. These warrant a minor version bump (6.5.0). The `build/dialog-updates` branch has 1 unmerged commit that should be included.
+
+## Pre-conditions
+
+- [ ] npm authentication working (`npm whoami` succeeds) — user must run `npm login` first
+- [ ] `build/dialog-updates` merged to `main`
+
+## Steps
+
+### Phase 1: Merge branch to main
+
+1. Create PR from `build/dialog-updates` → `main`
+2. Wait for user to approve/merge the PR
+3. Switch to `main` and pull latest
+
+### Phase 2: Validate
+
+4. Run build: `cd packages/fpkit && npm run build`
+5. Run lint: `npm run lint`
+6. Run tests: `npm test`
+7. Confirm `npm whoami` succeeds (user must `npm login` if not)
+
+### Phase 3: Release branch
+
+8. Create branch `release/v6.5.0` from `main`
+9. Run `lerna version minor --no-push --no-git-tag-version`
+10. Update `CHANGELOG.md` with release notes
+11. Commit version bump + changelog
+12. Push branch, create PR: `chore(release): publish @fpkit/acss@6.5.0`
+
+### Phase 4: Publish
+
+13. After PR merge, switch to `main` and pull
+14. Run `lerna publish from-package --yes --otp={code}`
+15. Push tags: `git push --follow-tags`
+16. Clean up release branch (local + remote)
+
+### Phase 5: Verify
+
+17. `npm view @fpkit/acss version` returns `6.5.0`
+18. `npm view @fpkit/acss dist-tags` shows `latest: 6.5.0`
+
+## Key files
+
+- `packages/fpkit/package.json` — version field
+- `CHANGELOG.md` — release notes
+- `lerna.json` — versioning config
+
+## Blockers
+
+- **npm auth failing (401)** — user must run `npm login` before Step 7

--- a/packages/fpkit/CHANGELOG.md
+++ b/packages/fpkit/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.5.0](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.5.0) (2026-03-08)
+
+
+### Bug Fixes
+
+* **dialog:** default position to center and update stories with position assertions ([d634f5d](https://github.com/shawn-sandy/fpkit/commit/d634f5dc41ac68b96c7401d5a3fd8bc233c761c8))
+* **dialog:** ensure modal centers by default with fit-content height ([36517f7](https://github.com/shawn-sandy/fpkit/commit/36517f7009c5cb9d6b4b9245a49c6e64105dfa08))
+* **dialog:** export DialogModal from package index ([269a245](https://github.com/shawn-sandy/fpkit/commit/269a245ffa1f1f5922427a07eb8c5c0219b57a8b))
+* **dialog:** format export of DialogProps and DialogModalProps types ([94d6898](https://github.com/shawn-sandy/fpkit/commit/94d689856d51b6b01e069a965b69e7c407f84760))
+
+
+### Features
+
+* **dialog:** add size and position props for modal sizing and placement ([33d5cde](https://github.com/shawn-sandy/fpkit/commit/33d5cde587a9cf15db6e80f288dae928bd9a858e))
+* **dialog:** export DialogProps and DialogModalProps types from package index ([434c0cf](https://github.com/shawn-sandy/fpkit/commit/434c0cf9d41eda837878747ea965339df35e1025))
+
+
+
+
+
 ## [6.4.3](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.4.3) (2026-03-07)
 
 

--- a/packages/fpkit/package-lock.json
+++ b/packages/fpkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fpkit/acss",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fpkit/acss",
-      "version": "6.4.3",
+      "version": "6.5.0",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -2,7 +2,7 @@
   "name": "@fpkit/acss",
   "description": "A lightweight React UI library for building modern and accessible components that leverage CSS custom properties for reactive Styles.",
   "private": false,
-  "version": "6.4.3",
+  "version": "6.5.0",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.0.0"


### PR DESCRIPTION
## Summary
- Bumps @fpkit/acss from 6.4.3 to 6.5.0 (minor)
- Includes dialog component updates: size/position props, IconButton refactor, centering fixes, full-size variant styles
- Auto-generated CHANGELOG via conventional commits

## Changes since 6.4.3
### Features
- **dialog:** add size and position props for modal sizing and placement
- **dialog:** export DialogProps and DialogModalProps types

### Bug Fixes
- **dialog:** default position to center and update stories
- **dialog:** ensure modal centers by default with fit-content height
- **dialog:** export DialogModal from package index

## Pre-publish validation
- [x] Build passes
- [x] Lint passes (0 errors)
- [x] All 998 tests pass (25 test files)
- [x] npm auth confirmed

## Post-merge
After merging, publish with: `lerna publish from-package --yes --otp=<code>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)