### PR TITLE
docs: sync README and guides with v6.x feature set

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -16,12 +16,10 @@
         "--prefix",
         "apps/astro-builds",
         "run",
-        "dev",
-        "--",
-        "--port",
-        "4327"
+        "dev"
       ],
-      "port": 4327
+      "port": 4327,
+      "autoPort": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -50,15 +50,17 @@ function App() {
 ## Available Components
 
 ### UI Components
-- **Alert** - Display important messages and notifications
+- **Alert** - Display important messages and notifications (semantic variants: error, success, warning, info)
 - **Badge** - Labels and status indicators with auto-scaling
 - **Breadcrumb** - Navigation path with improved accessibility
-- **Button** - Interactive button elements
+- **Button** - Interactive button elements (sizes `xs`–`2xl`, `block` for full-width, semantic `color`)
 - **Card** - Content containers with interactive features
 - **Details** - Collapsible content sections (WCAG AA compliant)
-- **Dialog** - Modal dialogs with controlled component pattern
+- **Dialog** - Modal dialogs with controlled component pattern; optional `icon` prop for IconButton triggers
+- **Fieldset** - Accessible fieldset wrapper with semantic `legend` support
 - **Form** - Form elements and validation
-- **Link** - Accessible link components
+- **IconButton** - Standalone icon button with accessible label (visually-hidden or responsive)
+- **Link** - Accessible link components (with WCAG 2.1.1-compliant `disabled` state)
 - **List** - Styled list components
 - **Modal** - Overlay modals and dialogs
 - **Nav** - Navigation components
@@ -67,7 +69,11 @@ function App() {
 - **Table** - Data table components
 - **Tag** - Tagging and categorization
 - **Text** - Typography components
-- **Title** - Semantic heading component (h1-h6)
+- **Title** - Semantic heading component (h1-h6) with size and color variants
+
+### Theming & Tokens
+- **ThemeProvider / ThemeToggle / useTheme** - Light/dark theming runtime (system-preference aware)
+- **`@fpkit/acss/tokens`** - DTCG-compliant design token JSON artifact
 
 ### Specialized Components
 - **Icons** - Icon library and components
@@ -75,16 +81,15 @@ function App() {
 - **TextToSpeech** - Text-to-speech functionality
 - **WordCount** - Word counting utilities
 
-## Recent Improvements
+## What's New in v6.x
 
-### v0.5.11
-- **Title Component** - New semantic heading component replacing deprecated Heading
-- **Dialog Refactoring** - Comprehensive refactoring with controlled component pattern and WCAG AA compliance
-- **Details Component** - Enhanced accessibility with live accessibility review
-- **Card Component** - Comprehensive refactoring with focus styles and interactive features
-- **Breadcrumb Enhancements** - Performance and accessibility improvements
-- **Badge Updates** - Auto-scaling functionality and enhanced styles
-- **Accessibility Focus** - Improved documentation and WCAG compliance across all components
+Major additions since `1.0.0-beta.0` (CSS-variable rename — see [MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md)):
+
+- **Theming runtime** — `ThemeProvider`, `useTheme`, `ThemeToggle`, and `getThemeFoucScript()` for SSR. Light/dark via a single `data-theme` attribute on `<html>`; system-preference tracking built in. See the [Theming guide](packages/fpkit/docs/guides/theming.md).
+- **Design token pipeline** — `@fpkit/acss/tokens` ships a DTCG-compliant JSON artifact with primitive and semantic colors (plus per-token dark-mode overrides), motion durations and easings, and responsive breakpoints. Ready for Figma bridges, docs sites, and custom builds. Typography and spacing tokens are on the roadmap. See the [Design Tokens guide](packages/fpkit/docs/guides/design-tokens.md).
+- **Public Astro docs site** — [apps/astro-builds/](apps/astro-builds/) renders Foundations pages (Colors, Typography, Spacing, Motion) and a live [component maturity dashboard](apps/astro-builds/src/pages/status.astro) derived from Storybook lifecycle tags.
+- **CI quality gates** — Vitest coverage thresholds, `size-limit` bundle budgets, axe-powered a11y auditing in the Storybook test-runner, and Changesets for versioning.
+- **New components / APIs** — `IconButton` (v6.3.0), `Fieldset` (v6.2.0), Button `xl` / `2xl` / `block`, Dialog `icon` prop, responsive display utilities, Alert `info` variant, Link `disabled` (WCAG 2.1.1 compliant).
 
 ## Importing Styles
 
@@ -102,6 +107,36 @@ Or import specific component styles:
 import '@fpkit/acss/css/button/button.css';
 import '@fpkit/acss/css/card/card.css';
 ```
+
+## Theming
+
+Ship light/dark theming without a flash of unthemed content:
+
+```tsx
+import { ThemeProvider, ThemeToggle } from '@fpkit/acss';
+
+function App() {
+  return (
+    <ThemeProvider defaultPreference="system">
+      <ThemeToggle />
+      {/* your app */}
+    </ThemeProvider>
+  );
+}
+```
+
+For SSR frameworks, `getThemeFoucScript()` returns an inline script string you place in `<head>` so `data-theme` is set before React hydrates. Framework-specific patterns (Next.js `app/layout.tsx`, Astro layouts, Remix) and the full API — `useTheme`, custom storage keys, creating additional themes — live in the [Theming guide](packages/fpkit/docs/guides/theming.md).
+
+## Design Tokens
+
+Consume the token JSON directly for docs sites, Figma bridges, and custom builds:
+
+```ts
+import tokens from '@fpkit/acss/tokens';
+// tokens.color.primary, tokens.duration.base, tokens.ease.standard, tokens.breakpoint.md
+```
+
+Tokens are DTCG-compliant (129 tokens as of v6.5) and include primitive color scales, semantic colors with per-token dark-mode overrides, motion (durations + easings), and responsive breakpoints. See the [Design Tokens guide](packages/fpkit/docs/guides/design-tokens.md) for the full shape and consumption patterns.
 
 ## Using Hooks
 
@@ -130,23 +165,37 @@ function MyComponent() {
 
 ## Monorepo Structure
 
-This is a Lerna-managed monorepo containing:
+This is a monorepo using Lerna for task orchestration and Changesets for versioning:
 
 ```
 acss/
 ├── packages/
 │   └── fpkit/              # Main component library (@fpkit/acss)
 ├── apps/
-│   └── astro-builds/       # Astro integration demo
+│   └── astro-builds/       # Public Astro docs site (Foundations + /status dashboard)
 ├── .storybook/             # Storybook configuration
 └── storybook-static/       # Built Storybook docs
+```
+
+## Docs Site & Component Maturity
+
+The project ships a companion Astro docs site at [apps/astro-builds/](apps/astro-builds/):
+
+- **Foundations pages** (`/foundations/colors`, `/foundations/typography`, `/foundations/spacing`, `/foundations/motion`) render live views straight from the token JSON — they stay in sync with the library automatically.
+- **Component maturity dashboard** at [/status](apps/astro-builds/src/pages/status.astro) shows every component's lifecycle stage (experimental → beta → rc → stable → deprecated) alongside coverage signals (tests present, a11y verified, dark-mode verified), auto-derived from Storybook tags. See the [component lifecycle guide](packages/fpkit/docs/guides/component-lifecycle.md) for promotion criteria.
+
+Run the docs site locally:
+
+```bash
+cd apps/astro-builds
+npm run dev
 ```
 
 ## Development
 
 ### Prerequisites
 
-- Node.js >= 20.9.0
+- Node.js >= 22.12.0
 - npm >= 8.0.0
 
 ### Setup
@@ -180,7 +229,8 @@ npm run dev              # Start Vite dev server
 npm start                # Watch mode: builds package + SASS
 
 # Building
-npm run build            # Full build pipeline
+npm run build            # Full build: tokens → TS → SCSS → CSS
+npm run tokens:build     # Extract tokens.json from SCSS sources
 npm run package          # Build TypeScript with tsup
 npm run sass:build       # Compile SCSS to CSS
 
@@ -188,7 +238,22 @@ npm run sass:build       # Compile SCSS to CSS
 npm test                 # Run Vitest tests
 npm run test:ui          # Run tests with UI
 npm run test:coverage    # Generate coverage report
+npm run size             # Check bundle-size budgets (size-limit)
+npm run size:why         # Visualize what's in each bundle
+
+# Publishing
+npm run changeset        # Create a changeset entry (at monorepo root)
+npm run version-packages # Apply changesets and bump versions
 ```
+
+### CI Quality Gates
+
+Contributors should know what the CI enforces before opening a PR:
+
+- **Test coverage thresholds** — configured in [packages/fpkit/vitest.config.js](packages/fpkit/vitest.config.js); failing below ~89% lines / 90% branches breaks the test job.
+- **Bundle-size budgets** — [packages/fpkit/.size-limit.cjs](packages/fpkit/.size-limit.cjs) caps the main build, hooks, icons, and CSS entry points. `npm run size` reports against the budget.
+- **Accessibility audit** — the Storybook test-runner wires axe via [.storybook/test-runner.ts](.storybook/test-runner.ts). Non-blocking during triage; flipping to blocking is tracked in [MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md).
+- **Versioning** — Changesets owns `CHANGELOG.md` and version bumps. Hand-edits to `CHANGELOG.md` will be clobbered on the next release.
 
 ## TypeScript Support
 

--- a/docs/planning/sync-readme-and-docs-with-v6.md
+++ b/docs/planning/sync-readme-and-docs-with-v6.md
@@ -1,0 +1,126 @@
+# Plan: Sync README and docs with recent changes
+
+## Context
+
+The root [README.md](README.md) still advertises v0.5.11 in its "Recent Improvements" section, but the package is now at v6.5.0 and has absorbed several major phases of work that are effectively invisible to visitors:
+
+- **Phase 2 / Phase 3** — design-token pipeline and a theming runtime (`ThemeProvider`, `useTheme`, `ThemeToggle`, FOUC script, `@fpkit/acss/tokens` JSON artifact)
+- **Phase 5** — CI quality gates (Vitest coverage thresholds, size-limit budgets, Changesets replacing Lerna versioning)
+- **Phase 6** — public Astro docs site at `apps/astro-builds/` with Foundations pages (Colors, Typography, Spacing, Motion)
+- **Phase 7A** — [/status](apps/astro-builds/src/pages/status.astro) component maturity dashboard derived from Storybook lifecycle tags
+- **Axe a11y gate** — Storybook test-runner now runs axe; currently non-blocking during triage
+- **New components / props** — `IconButton` (v6.3.0), `Fieldset` (v6.2.0), Button `xl`/`2xl`/`block`, Dialog `icon` prop, responsive display utilities, `color="info"`, `Link disabled`
+
+The [packages/fpkit/README.md](packages/fpkit/README.md) is more current (covers barrel vs. tree-shaken imports, accessibility posture) but still doesn't surface the theming runtime, tokens export, or docs-site/maturity-dashboard.
+
+Goal: bring both READMEs up to date and add just enough docs glue so users can discover the new capabilities. No new guide files — reuse the existing guides in [packages/fpkit/docs/guides/](packages/fpkit/docs/guides/).
+
+## Objective
+
+Update the two primary README files, the docs hub, and the package `engines` metadata so they accurately describe the v6.5.0 feature set (theming, tokens, Astro docs site, maturity dashboard, CI gates, new components). Add two new guide pages (theming, design tokens) to mirror the existing guide pattern. Leave CHANGELOG.md files alone — those are governed by Changesets going forward.
+
+## Critical Files to Modify
+
+| File | Current state | After |
+|---|---|---|
+| [README.md](README.md) | Pinned on v0.5.11; lists components only; no theming/tokens/docs-site | Fresh "What's New" summary for v6.x; new sections for Theming, Tokens, Docs Site + Status Dashboard, CI Gates; updated component list; Node >= 22.12 prerequisite |
+| [packages/fpkit/README.md](packages/fpkit/README.md) | Good on imports/a11y; silent on Phase 3/6/7A | Add Theming Runtime, Design Tokens, Component Maturity dashboard pointer; list IconButton/Fieldset under Core Components |
+| [packages/fpkit/docs/README.md](packages/fpkit/docs/README.md) | Docs hub | Add entries for new Theming guide, Design Tokens guide, Component Lifecycle guide, plus a link to the Astro /status page |
+| [package.json](package.json) | `engines.node` drifts from CLAUDE.md spec | Bump `engines.node` to `>= 22.12.0` |
+| [packages/fpkit/package.json](packages/fpkit/package.json) | Same drift | Bump `engines.node` to `>= 22.12.0` |
+
+## Critical Files to Create
+
+| File | Purpose |
+|---|---|
+| `packages/fpkit/docs/guides/theming.md` | New guide: `ThemeProvider`, `useTheme`, `ThemeToggle`, `getThemeFoucScript` (SSR FOUC prevention), custom theme recipes, dark-mode CSS variable overrides |
+| `packages/fpkit/docs/guides/design-tokens.md` | New guide: `@fpkit/acss/tokens` JSON artifact, token categories (colors, typography, spacing, motion, breakpoints, durations, easings), consumption patterns (Figma bridges, docs sites, custom builds), pointer to Foundations pages at [apps/astro-builds/src/pages/foundations/](apps/astro-builds/src/pages/foundations/) |
+
+## Existing assets to reuse (no duplication)
+
+- [packages/fpkit/docs/guides/component-lifecycle.md](packages/fpkit/docs/guides/component-lifecycle.md) — lifecycle vocabulary → link from dashboard blurb
+- [docs/css-variables.md](docs/css-variables.md) — already at v1.0.0, no edits required
+- [packages/fpkit/MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md) — the canonical breaking-changes doc → link from root README "What's New"
+- [apps/astro-builds/src/pages/status.astro](apps/astro-builds/src/pages/status.astro) and [apps/astro-builds/src/lib/component-status.ts](apps/astro-builds/src/lib/component-status.ts) — source for dashboard behavior; no code changes needed
+
+## Steps
+
+### Root README
+
+1. **Rewrite root [README.md](README.md) "Recent Improvements" into "What's New in v6.x".**
+   *Why:* The v0.5.11 section is ~12 versions stale and misleads first-time visitors. Link out to [MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md) rather than inlining breaking-change tables.
+
+2. **Add three new sections to root [README.md](README.md): Theming, Design Tokens, Docs Site & Component Maturity.**
+   *Why:* None of the Phase 3/6/7A capabilities are discoverable from the README today. Keep each section ≤ 8 lines with a one-line import snippet and a link to the new guide (Theming/Tokens) or the Astro /status page (Maturity).
+
+3. **Add a "CI Quality Gates" note to the Development section of root [README.md](README.md).**
+   *Why:* Contributors running `npm test` will hit the new coverage thresholds and `npm run size` budgets; they need to know why. Link to [.size-limit.cjs](.size-limit.cjs) and [packages/fpkit/vitest.config.js](packages/fpkit/vitest.config.js) as source-of-truth.
+
+4. **Update root [README.md](README.md) component list: add `IconButton`, `Fieldset`; note Button `xl`/`2xl`/`block`; note Dialog `icon` prop.**
+   *Why:* These are user-facing APIs added in 6.2–6.4 but missing from the list.
+
+5. **Update root [README.md](README.md) prerequisites: Node >= 22.12.0 (not 20.9.0).**
+   *Why:* [CLAUDE.md](CLAUDE.md) declares Node >= 22.12; the README says 20.9. Mirrors the `engines` bump in step 12.
+
+### Package README
+
+6. **Add "Theming Runtime" and "Design Tokens" subsections to [packages/fpkit/README.md](packages/fpkit/README.md) under the existing "Styling & Theming" section.**
+   *Why:* That section currently shows only raw CSS variables; readers never discover `ThemeProvider`, `useTheme`, `getThemeFoucScript`, or the `@fpkit/acss/tokens` JSON export. One code snippet per subsection; each links to its respective new guide.
+
+7. **Add `IconButton` and `Fieldset` to [packages/fpkit/README.md](packages/fpkit/README.md) "Core Components" with brief usage snippets.**
+   *Why:* Parity with the components already shown (Button, Card, Modal, Input, etc.).
+
+8. **Add a "Component Maturity" line to [packages/fpkit/README.md](packages/fpkit/README.md) Documentation section, linking to the Astro `/status` page and [component-lifecycle.md](packages/fpkit/docs/guides/component-lifecycle.md).**
+   *Why:* Dashboard lives on the Astro site; README just needs a pointer so users know it exists.
+
+### New guide pages
+
+9. **Create `packages/fpkit/docs/guides/theming.md`.**
+   Structure:
+   - What the theming runtime gives you (light/dark without style flashes)
+   - `ThemeProvider` — wrapping a React app, props, default theme selection
+   - `useTheme` — reading/writing the active theme from components
+   - `ThemeToggle` — drop-in UI component
+   - `getThemeFoucScript()` — inline `<script>` for SSR apps (Next.js `app/layout.tsx`, Astro `Layout.astro`) to prevent theme flash on first paint
+   - How theme switching works under the hood (data-attribute + CSS variable overrides in [packages/fpkit/src/styles/tokens/](packages/fpkit/src/styles/tokens/))
+   - Creating a custom theme (override the semantic color tokens for a third theme)
+   *Why:* Theming runtime is a meaningful public API with non-obvious SSR edge cases (FOUC); deserves a dedicated page rather than a README snippet.
+
+10. **Create `packages/fpkit/docs/guides/design-tokens.md`.**
+    Structure:
+    - Token categories exposed via `@fpkit/acss/tokens`: colors (primitive + semantic + dark overrides), typography, spacing, motion (durations + easings), breakpoints
+    - JSON shape — one top-level key per category, with an example
+    - Consumption patterns: importing in a Next.js/Astro site, feeding a Figma bridge, generating custom CSS at build time
+    - Pointer to live examples at [apps/astro-builds/src/pages/foundations/](apps/astro-builds/src/pages/foundations/) (Colors, Typography, Spacing, Motion pages rendered from the same JSON)
+    - Relationship to the `--component-*` CSS variables documented in [docs/css-variables.md](docs/css-variables.md): tokens are source-of-truth; CSS variables are consumer-facing override surface
+    *Why:* Token pipeline is the foundation of Phase 6 (docs site) and future Figma bridges; consumers currently have no discoverable doc describing the artifact.
+
+### Docs hub
+
+11. **Update [packages/fpkit/docs/README.md](packages/fpkit/docs/README.md) guide index.**
+    Add entries for: new Theming guide (step 9), new Design Tokens guide (step 10), Component Lifecycle guide (existing, unlisted), and an external link to the Astro `/status` page.
+    *Why:* The docs hub is the "front door" for guide discovery; new guides and the dashboard must be linked or they won't be found.
+
+### Engine metadata
+
+12. **Bump `engines.node` to `>= 22.12.0` in [package.json](package.json) and [packages/fpkit/package.json](packages/fpkit/package.json).**
+    *Why:* Mirrors the README prerequisite update (step 5) and makes the constraint enforced at `npm install` time rather than merely documented. Check all monorepo `package.json` files — update any that specify `engines.node`.
+
+## Verification
+
+- **Symbol accuracy check (before writing guide snippets):**
+  - `grep -rn "export.*ThemeProvider\|export.*useTheme\|export.*ThemeToggle\|getThemeFoucScript" packages/fpkit/src/` — confirm exact export names before they land in the theming guide.
+  - `grep -rn '"./tokens"' packages/fpkit/package.json` and read [packages/fpkit/libs/tokens.json](packages/fpkit/libs/tokens.json) (if built) to confirm the JSON shape described in the design-tokens guide.
+- **Link check:** `npx markdown-link-check README.md packages/fpkit/README.md packages/fpkit/docs/README.md packages/fpkit/docs/guides/theming.md packages/fpkit/docs/guides/design-tokens.md` — every relative link resolves.
+- **Visual review in Storybook:** `npm start` at the monorepo root and spot-check that the component list in the README matches what the sidebar exposes (IconButton, Fieldset, etc.).
+- **Astro docs preview:** `cd apps/astro-builds && npm run dev` — confirm the `/status` page loads and matches what the README says it shows (lifecycle + coverage matrix), and that the Foundations pages (`/foundations/colors`, `/foundations/typography`, `/foundations/spacing`, `/foundations/motion`) match the categories described in the design-tokens guide.
+- **Code-snippet smoke test:** copy the `ThemeProvider` and `@fpkit/acss/tokens` import snippets from the new guides into a scratch file and run `npx tsc --noEmit` against them with the current build output to confirm the imports resolve.
+- **`engines` enforcement test:** `rm -rf node_modules && npm install` on Node 20.x should now fail (or warn loudly) after the engines bump; on Node 22.12+ should succeed.
+- **Stale string sweep:** `grep -rn "v0.5.11\|0.5.11\|Node.js >= 20" README.md packages/fpkit/README.md` returns nothing.
+
+## Out of Scope / Next Steps
+
+- **CHANGELOG.md edits** — Changesets owns this now (Phase 5). If entries for Phases 6/7A are missing, add a Changeset via `npm run changeset` in a separate task.
+- **Consolidating MIGRATION-*.md files** — the tree has ~12 of them (v1.0.0-era + v7). A unified migration index would help, but is a separate effort.
+- **Deleting `docs/planning/` cruft** — many randomly-named planning files (`crispy-sprouting-clock.md`, etc.) should be renamed or archived via the `plan-hygiene` skill.
+- **Backfilling a11y and dark-mode verification tags** — the maturity dashboard reads `a11y-verified` / `dark-mode-verified` Storybook tags. Adding them to more components is a separate review pass.

--- a/packages/fpkit/README.md
+++ b/packages/fpkit/README.md
@@ -179,10 +179,12 @@ import { Button } from '@fpkit/acss';
 // Individual import
 import { Button } from '@fpkit/acss/button';
 
-// Usage
-<Button type="button" onClick={() => console.log('clicked')}>
+// Usage — sizes xs through 2xl, plus `block` for full-width
+<Button type="button" size="lg" onClick={() => console.log('clicked')}>
   Click me
 </Button>
+
+<Button type="submit" block>Full-width submit</Button>
 
 // With TypeScript
 import { Button, type ButtonProps } from '@fpkit/acss/button';
@@ -192,6 +194,24 @@ const buttonProps: ButtonProps = {
   disabled: false,
   children: 'Submit Form'
 };
+```
+
+### IconButton
+
+Icon-only button with a required accessible label and an optional visible text label:
+
+```tsx
+import { IconButton, Icon } from '@fpkit/acss';
+
+// Accessible-label-only (visually icon-only)
+<IconButton aria-label="Close dialog" onClick={handleClose}>
+  <Icon name="close" />
+</IconButton>
+
+// With a responsive label (hidden on small viewports, visible on larger)
+<IconButton aria-label="Settings" label="Settings">
+  <Icon name="settings" />
+</IconButton>
 ```
 
 ### Card
@@ -266,6 +286,25 @@ import { Field } from '@fpkit/acss';
 </Field>
 ```
 
+### Fieldset
+
+Accessible `<fieldset>` wrapper with a semantic `legend` — groups related form controls for screen readers:
+
+```tsx
+import { Fieldset } from '@fpkit/acss';
+
+<Fieldset legend="Shipping address">
+  <Field>
+    <Field.Label>Street</Field.Label>
+    <Input type="text" name="street" />
+  </Field>
+  <Field>
+    <Field.Label>City</Field.Label>
+    <Input type="text" name="city" />
+  </Field>
+</Fieldset>
+```
+
 ### Navigation
 
 Semantic navigation components:
@@ -330,6 +369,47 @@ FPKit uses CSS custom properties for theming and styling:
   --fp-button-padding: var(--fp-spacing-md);
 }
 ```
+
+### Theming Runtime (Light / Dark / System)
+
+FPKit ships a tiny theming runtime built around a single `data-theme` attribute on `<html>`. Wrap your app and drop in a toggle:
+
+```tsx
+import { ThemeProvider, ThemeToggle, useTheme } from '@fpkit/acss';
+
+function App() {
+  return (
+    <ThemeProvider defaultPreference="system">
+      <ThemeToggle />
+      <YourApp />
+    </ThemeProvider>
+  );
+}
+
+// In any child component:
+function SomeChild() {
+  const { theme, preference, setPreference } = useTheme();
+  // theme is always "light" or "dark"; preference can also be "system"
+  return <span>Current theme: {theme}</span>;
+}
+```
+
+**For SSR frameworks (Next.js, Astro, Remix):** `getThemeFoucScript()` returns an inline script string you render in `<head>` so `data-theme` is set synchronously before React hydrates — no flash of wrong theme on first paint. Framework-specific recipes and custom-theme authoring live in the [Theming guide](docs/guides/theming.md).
+
+### Design Tokens
+
+The library exports a DTCG-compliant JSON artifact for use in docs sites, Figma bridges, and custom build pipelines:
+
+```ts
+import tokens from '@fpkit/acss/tokens';
+
+// Primitive scales:  tokens.color.neutral[600], tokens.color.blue[600], ...
+// Semantic colors:   tokens.color.primary, tokens.color.error, tokens.color.surface, ...
+// Motion:            tokens.duration.base, tokens.ease.standard, ...
+// Layout:            tokens.breakpoint.md, tokens.breakpoint.lg, ...
+```
+
+There's also a typed TS export at `src/tokens/index.ts` (generated from SCSS) where each token resolves to its CSS custom property reference — `tokens.color.primary` returns `"var(--color-primary)"` so consumers get runtime theme switching for free. Dark-mode values live inside each semantic token's `$extensions.com.fpkit.themeModes.dark` slot. See the [Design Tokens guide](docs/guides/design-tokens.md) for the full shape, category breakdown, and consumption patterns.
 
 ### Component Styling
 
@@ -417,20 +497,28 @@ export default App;
 
 ### Core UI Components
 
-- **Button** - Accessible button with variants
+- **Button** - Accessible button with variants, sizes xs–2xl, `block` prop
+- **IconButton** - Icon-only button with required accessible label
 - **Card** - Flexible card container with composable parts
 - **Modal** - Accessible modal dialog
-- **Dialog** - General purpose dialog component
+- **Dialog** - General purpose dialog component (optional `icon` trigger)
 - **Input** - Form input with validation
 - **Field** - Form field wrapper with label and error
-- **Link** - Accessible link component
+- **Fieldset** - Accessible fieldset + legend wrapper for grouped form controls
+- **Link** - Accessible link component (WCAG 2.1.1-compliant `disabled` state)
 - **List** - Semantic list components
+
+### Theming & Tokens
+
+- **ThemeProvider / useTheme / ThemeToggle** - Light/dark theming runtime
+- **`getThemeFoucScript()`** - SSR script to prevent theme flash
+- **`@fpkit/acss/tokens`** - DTCG design token JSON artifact
 
 ### Layout Components
 
 - **Box** - Generic container component
 - **Nav** - Navigation components
-- **Landmarks** - Semantic landmark components
+- **Landmarks** - Semantic landmark components (Header, Main, Footer, Aside, Fieldset)
 
 ### Typography
 
@@ -525,10 +613,13 @@ Comprehensive guides to help you build accessible, maintainable applications wit
 
 ### Core Guides
 
+- **[Theming Guide](docs/guides/theming.md)** - `ThemeProvider`, `useTheme`, `ThemeToggle`, SSR FOUC handling, and creating custom themes
+- **[Design Tokens Guide](docs/guides/design-tokens.md)** - Consume the `@fpkit/acss/tokens` JSON artifact; token categories and integration patterns
 - **[CSS Variables Guide](docs/guides/css-variables.md)** - Learn how to discover and customize CSS custom properties for theming and styling
 - **[Composition Guide](docs/guides/composition.md)** - Master component composition patterns to build custom components by combining fpkit primitives
 - **[Accessibility Guide](docs/guides/accessibility.md)** - Understand and maintain WCAG 2.1 Level AA compliance when using and composing components
 - **[Architecture Guide](docs/guides/architecture.md)** - Learn fpkit's architectural patterns, component structure, and how to work effectively with the library
+- **[Component Lifecycle](docs/guides/component-lifecycle.md)** - Lifecycle stages (experimental → beta → rc → stable → deprecated) and promotion criteria
 - **[Testing Guide](docs/guides/testing.md)** - Test applications and custom components using Vitest and React Testing Library
 - **[Storybook Guide](docs/guides/storybook.md)** - Document custom components and compositions using Storybook
 
@@ -536,6 +627,7 @@ Comprehensive guides to help you build accessible, maintainable applications wit
 
 - **[Documentation Index](docs/README.md)** - Complete documentation hub with guide navigator and workflows
 - **[Storybook](https://fpkit.netlify.app/)** - Interactive component documentation and playground
+- **[Component Maturity Dashboard](../../apps/astro-builds/src/pages/status.astro)** - Live view of every component's lifecycle stage and coverage signals (tests, a11y, dark mode) on the Astro docs site
 
 ### Common Tasks
 

--- a/packages/fpkit/docs/README.md
+++ b/packages/fpkit/docs/README.md
@@ -6,6 +6,42 @@ Welcome to the @fpkit/acss documentation! This collection of guides helps you bu
 
 ## 📚 Guides
 
+### [Theming Guide](./guides/theming.md)
+
+Ship light/dark theming without a flash of the wrong theme on first paint.
+
+**Topics:**
+- `ThemeProvider`, `useTheme`, `ThemeToggle`
+- How the `data-theme` attribute powers runtime switching
+- `getThemeFoucScript()` for SSR (Astro, Next.js, Remix)
+- Creating a custom theme
+- Accessibility notes (`prefers-color-scheme`, toggle labeling)
+
+**Use when:**
+- Adding light/dark mode to an app
+- Preventing theme flash in SSR frameworks
+- Building a custom theme on top of fpkit
+
+---
+
+### [Design Tokens Guide](./guides/design-tokens.md)
+
+Consume `@fpkit/acss/tokens` — the DTCG-compliant design token artifact that powers the Figma bridge and the public docs site.
+
+**Topics:**
+- Shipped categories: color, motion, breakpoints (typography and spacing are on the roadmap)
+- The JSON artifact vs. the typed TS module (`var()` references)
+- Feeding Figma bridges, docs sites, and custom CSS generators
+- The extract-tokens + Style Dictionary pipeline
+- Relationship to CSS variables
+
+**Use when:**
+- Building a docs site or design-system tool that reads fpkit tokens
+- Bridging fpkit values into Figma variables
+- Generating custom CSS output from the same source
+
+---
+
 ### [CSS Variables Guide](./guides/css-variables.md)
 
 Learn how to discover, customize, and override CSS custom properties in fpkit components.
@@ -132,6 +168,23 @@ Document custom components and compositions using Storybook for development and 
 
 ---
 
+### [Component Lifecycle Guide](./guides/component-lifecycle.md)
+
+Understand the lifecycle tags (`experimental`, `beta`, `rc`, `stable`, `deprecated`) and the promotion criteria between them.
+
+**Topics:**
+- Lifecycle stage definitions and what they promise users
+- How tags are applied in Storybook story meta objects
+- Coverage signals that feed the [Component Maturity Dashboard](../../../apps/astro-builds/src/pages/status.astro): `hasTests`, `a11y-verified`, `dark-mode-verified`
+- Promotion checklist for moving a component stage up (or demoting it)
+
+**Use when:**
+- Authoring a new component and choosing its initial lifecycle stage
+- Reviewing whether a component is ready to promote from beta → rc → stable
+- Reading the `/status` dashboard and interpreting its signals
+
+---
+
 ## 🚀 Quick Start
 
 ### Installation
@@ -167,6 +220,9 @@ function App() {
 
 ### I want to...
 
+**Add light/dark theming to my app**
+→ Follow [Theming Guide](./guides/theming.md) (and the [Design Tokens Guide](./guides/design-tokens.md) if building a docs site or Figma bridge)
+
 **Customize component appearance**
 → Start with [CSS Variables Guide](./guides/css-variables.md)
 
@@ -181,6 +237,9 @@ function App() {
 
 **Document components**
 → Learn [Storybook Guide](./guides/storybook.md)
+
+**Promote a component from beta → stable (or author a new one)**
+→ Read [Component Lifecycle Guide](./guides/component-lifecycle.md) and check the [`/status` dashboard](../../../apps/astro-builds/src/pages/status.astro)
 
 **Understand fpkit patterns**
 → Start with [Architecture Guide](./guides/architecture.md)
@@ -207,10 +266,12 @@ function App() {
 
 ### Creating a Theme
 
-1. **Variables** - Discover customizable CSS variables ([CSS Variables Guide](./guides/css-variables.md))
-2. **Contrast** - Verify color contrast ratios ([Accessibility Guide](./guides/accessibility.md))
-3. **Testing** - Test theme across components ([Testing Guide](./guides/testing.md))
-4. **Documentation** - Document theme in Storybook ([Storybook Guide](./guides/storybook.md))
+1. **Runtime** - Understand light/dark runtime switching ([Theming Guide](./guides/theming.md))
+2. **Tokens** - Know what color categories exist ([Design Tokens Guide](./guides/design-tokens.md))
+3. **Variables** - Discover customizable CSS variables ([CSS Variables Guide](./guides/css-variables.md))
+4. **Contrast** - Verify color contrast ratios ([Accessibility Guide](./guides/accessibility.md))
+5. **Testing** - Test theme across components ([Testing Guide](./guides/testing.md))
+6. **Documentation** - Document theme in Storybook ([Storybook Guide](./guides/storybook.md))
 
 ---
 
@@ -264,6 +325,8 @@ Learn more in the [Architecture Guide](./guides/architecture.md).
 - [GitHub Repository](https://github.com/shawn-sandy/acss)
 - [Storybook Documentation](https://fpkit.netlify.app) _(if deployed)_
 - [npm Package](https://www.npmjs.com/package/@fpkit/acss)
+- [Component Maturity Dashboard](../../../apps/astro-builds/src/pages/status.astro) - Live view of every component's lifecycle and coverage
+- [Astro Foundations Pages](../../../apps/astro-builds/src/pages/foundations/) - Colors, Typography, Spacing, Motion rendered from tokens
 
 ### Web Standards
 - [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)
@@ -310,16 +373,21 @@ Found an issue or want to contribute? Visit our [GitHub repository](https://gith
 docs/
 ├── README.md (this file)
 └── guides/
-    ├── css-variables.md      - Styling and customization
-    ├── composition.md         - Component composition patterns
-    ├── accessibility.md       - WCAG compliance and a11y
-    ├── architecture.md        - Component structure and patterns
-    ├── testing.md            - Testing strategies
-    └── storybook.md          - Component documentation
+    ├── theming.md              - Light/dark runtime and custom themes
+    ├── design-tokens.md        - @fpkit/acss/tokens artifact and pipeline
+    ├── css-variables.md        - Styling and customization
+    ├── composition.md          - Component composition patterns
+    ├── accessibility.md        - WCAG compliance and a11y
+    ├── architecture.md         - Component structure and patterns
+    ├── component-lifecycle.md  - Lifecycle stages and promotion criteria
+    ├── design-principles.md    - Design system principles
+    ├── variants.md             - Variant authoring patterns
+    ├── testing.md              - Testing strategies
+    └── storybook.md            - Component documentation
 ```
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: 2025-01-05
+**Version**: 1.1.0
+**Last Updated**: 2026-04-17
 **License**: MIT

--- a/packages/fpkit/docs/guides/design-tokens.md
+++ b/packages/fpkit/docs/guides/design-tokens.md
@@ -1,0 +1,242 @@
+# Design Tokens Guide
+
+@fpkit/acss ships a DTCG-compliant JSON token artifact at `@fpkit/acss/tokens`, plus a typed TypeScript companion that resolves to CSS custom properties. This guide covers the shape of that artifact and how to consume it.
+
+- [Why tokens, not just CSS variables?](#why-tokens-not-just-css-variables)
+- [Shipped categories](#shipped-categories)
+- [The JSON artifact — `@fpkit/acss/tokens`](#the-json-artifact--fpkitacsstokens)
+- [The typed TS artifact — `src/tokens/index.ts`](#the-typed-ts-artifact--srctokensindexts)
+- [Consumption patterns](#consumption-patterns)
+- [The build pipeline](#the-build-pipeline)
+- [Relationship to CSS variables](#relationship-to-css-variables)
+
+---
+
+## Why tokens, not just CSS variables?
+
+The component library has always exposed CSS custom properties for styling (see [CSS Variables Guide](./css-variables.md)). Those are the *consumer-facing override surface* — what you set in your app's CSS to theme the library.
+
+Design tokens are a separate concern: a *portable, machine-readable description* of the design system's values. They unlock:
+
+- **Figma bridges** — the Figma plugin reads the JSON and offers tokens as Figma variables, so designers pick from the same palette the code uses.
+- **Docs sites** — the Astro docs app at [apps/astro-builds/](../../../../apps/astro-builds/) renders Foundations pages ([Colors](../../../../apps/astro-builds/src/pages/foundations/colors.astro), [Typography](../../../../apps/astro-builds/src/pages/foundations/typography.astro), [Spacing](../../../../apps/astro-builds/src/pages/foundations/spacing.astro), [Motion](../../../../apps/astro-builds/src/pages/foundations/motion.astro)) straight from the JSON, so the docs stay in sync with the library automatically.
+- **Cross-platform consumers** — any tool that speaks DTCG (native iOS/Android, Qt, Flutter generators) can consume the same tokens.
+
+**SCSS is the source of truth**, not JSON. Designers and library authors edit SCSS tokens in [packages/fpkit/src/sass/tokens/](../../src/sass/tokens/); the JSON is a generated artifact rebuilt by `npm run tokens:build`.
+
+---
+
+## Shipped categories
+
+As of v6.5, the extracted JSON covers **three** categories:
+
+| Category | Source | Notes |
+|---|---|---|
+| **Color** | [_color-primitives.scss](../../src/sass/tokens/_color-primitives.scss), [_color-semantic.scss](../../src/sass/tokens/_color-semantic.scss) | Two tiers: primitive scales (neutral, blue, green, red, amber, cyan — each with 100–900 steps) and semantic mappings (`primary`, `secondary`, `success`, `error`, `warning`, `info`, `surface`, `text`, etc.). Semantic mappings nest their own `.hover` and `.active` variants. Dark-mode overrides live in `[data-theme="dark"]` blocks in SCSS and are extracted into a per-token `$extensions.com.fpkit.themeModes.dark` slot. |
+| **Motion** | [_motion.scss](../../src/sass/tokens/_motion.scss) | Durations (`instant`, `fast`, `base`, `slow`, `slower`) and easings (`standard`, `accelerate`, `decelerate`, `emphasized`). |
+| **Breakpoints** | [_breakpoints.scss](../../src/sass/tokens/_breakpoints.scss) | Responsive layout thresholds in `rem` (`reflow` 20rem, `xs` 23.4375rem, `sm` 30rem, `md` 48rem, `lg` 62rem, `xl` 80rem, `2xl` 96rem). |
+
+**Not yet in the token pipeline** (but exposed as CSS variables):
+
+- **Typography** — font families, sizes, weights, line heights. Planned for a future tokens pass; today they live in [_type.scss](../../src/sass/_type.scss) and component-scoped SCSS.
+- **Spacing** — a spacing scale is not yet centrally defined as tokens; components reference literal `rem` values or component-scoped variables like `--btn-padding-inline`.
+
+Track the roadmap for typography + spacing in [MIGRATION-v7.md](../../MIGRATION-v7.md).
+
+---
+
+## The JSON artifact — `@fpkit/acss/tokens`
+
+Exposed via the package subpath export:
+
+```ts
+import tokens from '@fpkit/acss/tokens';
+```
+
+The artifact is DTCG-formatted (Design Tokens Community Group spec), produced by Style Dictionary. As of v6.5, 129 tokens extract from the SCSS sources.
+
+**Top-level categories:** `color`, `duration`, `ease`, `breakpoint`.
+
+Each leaf has `$value` and `$type`. Semantic colors nest their own `hover`/`active` variants. Dark-mode values live inside a per-token `$extensions.com.fpkit.themeModes.dark` slot — not a separate theme slice. Shape sketch:
+
+```jsonc
+{
+  "color": {
+    "blue": {
+      "600": {
+        "key": "{color.blue.600}",
+        "$value": "#2563eb",
+        "$type": "color",
+        "path": ["color", "blue", "600"]
+        // ...plus Style Dictionary metadata: name, attributes, original, filePath, isSource
+      }
+      // ...full neutral, blue, green, red, amber, cyan scales
+    },
+    "primary": {
+      "$value": "#2563eb",
+      "$type": "color",
+      "$extensions": {
+        "com.fpkit.themeModes": { "dark": "#3b82f6" }
+      },
+      "hover":  { "$value": "#1d4ed8", "$extensions": { "com.fpkit.themeModes": { "dark": "#60a5fa" } } },
+      "active": { "$value": "#1e40af", "$extensions": { "com.fpkit.themeModes": { "dark": "#93c5fd" } } }
+    },
+    "error":   { "$value": "#dc2626", /* same nesting as primary */ },
+    "success": { /* ... */ },
+    "warning": { /* ... */ },
+    "surface": { /* ... */ },
+    "text":    { /* ... */ }
+    // full list of semantic groups: primary, secondary, success, error, warning, info,
+    // surface, border, text, focus, ui, hover, active, disabled, link, required,
+    // valid, invalid, skip
+  },
+  "duration":   { "instant": {...}, "fast": {...}, "base": {...}, "slow": {...}, "slower": {...} },
+  "ease":       { "standard": {...}, "accelerate": {...}, "decelerate": {...}, "emphasized": {...} },
+  "breakpoint": { "reflow": {...}, "xs": {...}, "sm": {...}, "md": {...}, "lg": {...}, "xl": {...}, "2xl": {...} }
+}
+```
+
+Every leaf also carries Style Dictionary's bookkeeping (`name`, `attributes`, `original`, `filePath`, `isSource`) — useful if you're building tooling on top, ignorable if you only need `$value` and `$type`.
+
+> **Check the actual shape before building against it.** Run `npm run tokens:build` once in `packages/fpkit/` and inspect the output at `packages/fpkit/libs/tokens.json` — the sketch above is a shape guide, not a frozen contract.
+
+### Reading dark-mode values
+
+For tools that need both light and dark (Figma plugins with multiple modes, cross-platform theming):
+
+```ts
+import tokens from '@fpkit/acss/tokens';
+
+const light = tokens.color.primary.$value;                                        // "#2563eb"
+const dark  = tokens.color.primary.$extensions?.['com.fpkit.themeModes']?.dark;   // "#3b82f6"
+```
+
+Not every token defines a dark override — primitives (like `color.blue.600`) don't need one because only the semantic mappings flip. If `$extensions` is absent, the light value is used in both modes.
+
+---
+
+## The typed TS artifact — `src/tokens/index.ts`
+
+The same build step also emits a TypeScript module where each token resolves to a **CSS variable reference**, not a raw value:
+
+```ts
+// Generated file — do not edit by hand
+export const tokens = {
+  color: {
+    primary:      `var(--color-primary)`,
+    primaryHover: `var(--color-primary-hover)`,
+    error:        `var(--color-error)`,
+    // ...
+  },
+  duration: {
+    base: `var(--duration-base)`,
+    fast: `var(--duration-fast)`,
+  },
+  // ...
+} as const;
+
+export type Tokens = typeof tokens;
+```
+
+This is the module you want for **runtime theme switching**. Because each entry is a `var()` reference, the resolved color follows whatever `[data-theme]` is active on `<html>` — no rebuild required.
+
+```tsx
+import { tokens } from '@fpkit/acss/tokens'; // typed export
+
+const styles = {
+  color: tokens.color.primary,     // "var(--color-primary)"
+  transition: `color ${tokens.duration.base} ${tokens.ease.standard}`,
+};
+
+<div style={styles}>Themed at runtime</div>;
+```
+
+> **Two outputs, different jobs:** The JSON is the *design-system artifact* (cross-platform, portable). The TS module is the *React runtime convenience* (typed, theme-aware at runtime). Most apps want the TS module; tools want the JSON.
+
+---
+
+## Consumption patterns
+
+### Using tokens in a Next.js or Astro docs site
+
+Import the JSON directly and render it — that's how the fpkit Astro docs site renders its [Foundations pages](../../../../apps/astro-builds/src/pages/foundations/). Reference implementation:
+
+```tsx
+import tokens from '@fpkit/acss/tokens';
+
+export function ColorSwatches() {
+  return (
+    <ul>
+      {Object.entries(tokens.color)
+        .filter(([, v]) => '$value' in v)
+        .map(([name, v]) => (
+          <li key={name} style={{ background: v.$value }}>{name}</li>
+        ))}
+    </ul>
+  );
+}
+```
+
+### Feeding a Figma bridge
+
+Point your Figma plugin at the JSON path (`node_modules/@fpkit/acss/libs/tokens.json`) or the SCSS-to-Figma variable bridge of your choice. The DTCG `$type` fields map one-to-one with Figma's variable types (`color`, `number`, `string`).
+
+### Generating custom CSS at build time
+
+If you want a CSS output keyed on your own prefix (e.g. `--mybrand-*` instead of `--color-*`), feed `tokens.json` into Style Dictionary with a custom transform:
+
+```js
+// Your build script
+import tokens from '@fpkit/acss/tokens';
+// ...run through style-dictionary or your preferred generator
+```
+
+### Dark-theme-aware consumers
+
+For tools that need both light and dark values (e.g. a Figma plugin with two token modes), read each semantic token's `$value` for the light value and `$extensions["com.fpkit.themeModes"].dark` for the dark value. Primitive scales don't carry dark overrides — only semantic mappings do.
+
+---
+
+## The build pipeline
+
+Two stages, orchestrated by `npm run tokens:build` in `packages/fpkit/`:
+
+1. **Extract** — [scripts/extract-tokens.mjs](../../scripts/extract-tokens.mjs) compiles [src/sass/tokens/_index.scss](../../src/sass/tokens/_index.scss) via Sass, walks the resulting CSS AST with PostCSS, and emits a DTCG-formatted intermediate at `tokens/generated/source.json`.
+2. **Build** — [style-dictionary.config.mjs](../../style-dictionary.config.mjs) reads that intermediate and writes two outputs:
+   - `libs/tokens.json` — the artifact consumed by external tools (Figma, docs site, native apps)
+   - `src/tokens/index.ts` — the typed TS module consumed by React apps
+
+The full library build (`npm run build`) runs `tokens:build` first, so `libs/tokens.json` is always in sync with the compiled JS. The Astro docs site guards against stale state via an `ensure-fpkit-build` prescript that rebuilds the library if `libs/tokens.json` is missing.
+
+### Regenerating after editing SCSS
+
+```bash
+cd packages/fpkit
+npm run tokens:build
+```
+
+Then commit both generated files along with your SCSS edits — they're checked into the repo so consumers using the package as a workspace dependency don't need to rebuild.
+
+---
+
+## Relationship to CSS variables
+
+Tokens and CSS variables are two views of the same underlying data:
+
+| Aspect | CSS Variables (`--color-primary`) | Tokens (`@fpkit/acss/tokens`) |
+|---|---|---|
+| Authored in | SCSS | Generated from SCSS |
+| Changes at runtime | Yes — live under `[data-theme]` switching | The JSON is static; the TS `var()` references are live |
+| Who sets overrides | Consumer's CSS (your `:root` rules) | Tokens are read-only to consumers |
+| What to use for | Component styling, theme overrides | Design-system tooling (Figma, docs, cross-platform) |
+| Discovery | IDE autocomplete on `--`, see [CSS Variables Guide](./css-variables.md) | TypeScript autocomplete on `tokens.` |
+
+Use the CSS variables for *styling decisions* (what a component looks like). Use the tokens for *system decisions* (what colors and motion the whole library offers).
+
+---
+
+## See also
+
+- [Theming Guide](./theming.md) — runtime light/dark switching that flips the tokens live
+- [CSS Variables Guide](./css-variables.md) — the consumer-facing override surface
+- [Foundations pages in the Astro docs site](../../../../apps/astro-builds/src/pages/foundations/) — live reference rendered directly from these tokens

--- a/packages/fpkit/docs/guides/theming.md
+++ b/packages/fpkit/docs/guides/theming.md
@@ -1,0 +1,267 @@
+# Theming Guide
+
+@fpkit/acss ships a small theming runtime — `ThemeProvider`, `useTheme`, `ThemeToggle`, and `getThemeFoucScript` — for shipping light/dark themes without a flash of the wrong colors on first paint.
+
+This guide covers:
+
+- [How it works](#how-it-works)
+- [Quick start](#quick-start)
+- [`ThemeProvider`](#themeprovider)
+- [`useTheme`](#usetheme)
+- [`ThemeToggle`](#themetoggle)
+- [Preventing theme flash (SSR)](#preventing-theme-flash-ssr)
+- [Creating a custom theme](#creating-a-custom-theme)
+- [API reference](#api-reference)
+- [Accessibility notes](#accessibility-notes)
+
+---
+
+## How it works
+
+The runtime is built on a single DOM contract: a `data-theme="light|dark"` attribute on `<html>`. All theme-dependent CSS variables are re-declared under `[data-theme="dark"]` selectors in [packages/fpkit/src/styles/tokens/](../../src/sass/tokens/), so toggling the attribute switches every token-driven component at once — no re-render required.
+
+Responsibilities split three ways:
+
+- **`ThemeProvider`** owns the user's *preference* (`"light"`, `"dark"`, or `"system"`), resolves `"system"` against `prefers-color-scheme`, and writes `data-theme` on every change.
+- **`useTheme`** reads/writes preference from React components.
+- **`getThemeFoucScript()`** returns a tiny inline script (<500 bytes) for SSR consumers to apply the stored preference *before* React hydrates — otherwise you see a flash of the server-rendered default.
+
+The preference is persisted to `localStorage` under the key `"fpkit-theme-preference"` (configurable via `ThemeProvider`'s `storageKey` prop).
+
+---
+
+## Quick start
+
+Wrap your app:
+
+```tsx
+import { ThemeProvider, ThemeToggle } from '@fpkit/acss';
+
+function App() {
+  return (
+    <ThemeProvider defaultPreference="system">
+      <header>
+        <ThemeToggle />
+      </header>
+      <main>{/* your app */}</main>
+    </ThemeProvider>
+  );
+}
+```
+
+That's enough for a client-only app. For SSR, see [Preventing theme flash (SSR)](#preventing-theme-flash-ssr).
+
+---
+
+## `ThemeProvider`
+
+Context provider that owns theme state. Place it once, as high in the tree as possible.
+
+```tsx
+import { ThemeProvider } from '@fpkit/acss';
+
+<ThemeProvider
+  defaultPreference="system"           // "light" | "dark" | "system"
+  storageKey="my-app-theme-preference" // optional, namespace per app
+>
+  {children}
+</ThemeProvider>
+```
+
+| Prop | Type | Default | Purpose |
+|---|---|---|---|
+| `children` | `ReactNode` | — | Subtree that can read theme via `useTheme` |
+| `defaultPreference` | `"light" \| "dark" \| "system"` | `"system"` | Initial preference before the stored value loads |
+| `storageKey` | `string` | `"fpkit-theme-preference"` | Where the preference persists in `localStorage` |
+
+**What it does on mount:**
+
+1. Reads `localStorage[storageKey]` — falls back to `defaultPreference` if missing.
+2. Resolves `"system"` against `window.matchMedia('(prefers-color-scheme: dark)')`.
+3. Sets `data-theme` on `<html>`.
+4. Subscribes to `prefers-color-scheme` change events so "system" mode stays in sync when the OS theme changes at runtime.
+
+---
+
+## `useTheme`
+
+Hook that exposes the current state and setters. **Must be called inside a `ThemeProvider`** — it throws otherwise, intentionally, to prevent the silent desync bugs that default-to-light fallbacks cause.
+
+```tsx
+import { useTheme } from '@fpkit/acss';
+
+function ProfileMenu() {
+  const { theme, preference, setPreference, toggleTheme } = useTheme();
+
+  return (
+    <div>
+      <p>Current: {theme}</p>          {/* "light" | "dark" — never "system" */}
+      <p>Preference: {preference}</p>  {/* "light" | "dark" | "system" */}
+
+      <button onClick={() => setPreference('light')}>Light</button>
+      <button onClick={() => setPreference('dark')}>Dark</button>
+      <button onClick={() => setPreference('system')}>Match system</button>
+
+      <button onClick={toggleTheme}>Cycle light → dark → system</button>
+    </div>
+  );
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `preference` | `"light" \| "dark" \| "system"` | What the user asked for |
+| `theme` | `"light" \| "dark"` | What's actually applied right now |
+| `setPreference` | `(next) => void` | Persists to `localStorage` and updates DOM |
+| `toggleTheme` | `() => void` | Cycles light → dark → system → light |
+
+Use `setPreference` when you're building a picker (three explicit buttons). Use `toggleTheme` for the single-button cycler pattern — that's what `ThemeToggle` does internally.
+
+---
+
+## `ThemeToggle`
+
+Drop-in button that cycles through light → dark → system. Rendered as a `<Button variant="text">` so it inherits focus/keyboard handling automatically.
+
+```tsx
+import { ThemeToggle } from '@fpkit/acss';
+
+// Default: icon + text
+<ThemeToggle />
+
+// Icon only (accessible label still set via aria-label)
+<ThemeToggle display="icon" />
+
+// Text only
+<ThemeToggle display="text" />
+
+// Custom accessible label prefix
+<ThemeToggle srLabel="Theme is currently" />
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `display` | `"icon" \| "text" \| "both"` | `"both"` |
+| `srLabel` | `string` | `"Current theme:"` |
+| `className` | `string` | — |
+
+For more complex UI (a settings menu with three explicit radio buttons, a dropdown picker), compose your own component with `useTheme()` instead — `ThemeToggle` is optimized for the common header-bar use case.
+
+---
+
+## Preventing theme flash (SSR)
+
+The problem: in SSR, the server renders with one theme (usually the default), then React hydrates on the client and `ThemeProvider` reads `localStorage` and sets the correct theme. That gap — render → hydrate → read → set — produces a visible flash for users whose stored preference doesn't match the server default.
+
+The fix: inline a sub-500-byte script in `<head>` that reads `localStorage` synchronously and sets `data-theme` before the first paint. `getThemeFoucScript()` returns exactly that script as a string:
+
+```ts
+import { getThemeFoucScript } from '@fpkit/acss';
+
+const script = getThemeFoucScript();
+// (function(){ try { ... document.documentElement.setAttribute('data-theme', t); } catch(_){} })();
+```
+
+You then inline this string as the body of a `<script>` element in your document head. **How** you inline it depends on the framework — the mechanics differ, the script content does not.
+
+### Astro
+
+Astro's `set:html` directive renders a raw string into an inline `<script>`. Pair with `is:inline` so the script isn't bundled and runs synchronously before hydration:
+
+```astro
+---
+import { getThemeFoucScript } from '@fpkit/acss';
+---
+<!doctype html>
+<html>
+  <head>
+    <script is:inline set:html={getThemeFoucScript()} />
+    {/* ... */}
+  </head>
+  <body><slot /></body>
+</html>
+```
+
+### Next.js (App Router)
+
+In `app/layout.tsx`, render a `<script>` element whose content is `getThemeFoucScript()`. The canonical way to inline arbitrary script text inside a React element tree is via the element's raw-HTML escape hatch; Next.js's own docs use this pattern for analytics and theme scripts, so you can safely follow the recipe from [the Next.js theming docs](https://nextjs.org/docs/app/api-reference/components/script).
+
+Two things to know:
+
+- The script content is a hardcoded string produced by fpkit — it is not user-supplied, so the standard XSS considerations around raw HTML injection do not apply here. (Never pass user input through `getThemeFoucScript`; it's not a template.)
+- Add `suppressHydrationWarning` to the `<html>` element. The FOUC script sets `data-theme` before React hydrates, which produces a legitimate attribute-mismatch warning without this flag.
+
+### Remix
+
+Same shape as Next.js: inline the script string in `<head>` from `app/root.tsx`. Remix's documentation covers the raw-HTML-in-React pattern under the name *inline scripts*.
+
+### Custom storage key
+
+Pair `ThemeProvider`'s `storageKey` prop with `getThemeFoucScript(storageKey)`. **Both must match** — mismatched keys make the FOUC script read the wrong slot and the flash comes back:
+
+```tsx
+// App
+<ThemeProvider storageKey="my-app-theme">{children}</ThemeProvider>
+
+// Document head script source
+getThemeFoucScript('my-app-theme');
+```
+
+---
+
+## Creating a custom theme
+
+The two built-in themes live in [packages/fpkit/src/styles/tokens/](../../src/sass/tokens/) as `:root` declarations (light, the default) and `[data-theme="dark"]` overrides (dark). To add a third theme (say `"sepia"`):
+
+1. **Add the override block** in your app CSS (or a new SCSS partial):
+
+   ```css
+   [data-theme="sepia"] {
+     --color-background: #f4ecd8;
+     --color-text: #433422;
+     --color-primary: #8b5a2b;
+     /* ...etc. Only override what differs from :root. */
+   }
+   ```
+
+2. **Drive `data-theme` yourself.** `ThemeProvider` accepts `"light" | "dark" | "system"` out of the box — for additional named themes, call `document.documentElement.setAttribute('data-theme', 'sepia')` from your own picker component. `useTheme()` will still report the last `"light"` or `"dark"` value; if your app needs the richer state, maintain it in your own context.
+
+> **Note:** The library's built-in components are tested against light and dark only. Custom themes are your responsibility to verify for contrast and readability — see the [Accessibility guide](./accessibility.md) for the WCAG 2.1 AA color-contrast rules.
+
+---
+
+## API reference
+
+All exports are available from the main barrel `@fpkit/acss`:
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `ThemeProvider` | component | Owns theme state; provides context |
+| `ThemeToggle` | component | Single-button cycler (light → dark → system) |
+| `useTheme` | hook | Read/write theme from components |
+| `getThemeFoucScript(storageKey?)` | function | Returns inline script string for SSR FOUC prevention |
+| `THEME_STORAGE_KEY` | constant | Default `localStorage` key (`"fpkit-theme-preference"`) |
+| `ThemePreference` | type | `"light" \| "dark" \| "system"` |
+| `ResolvedTheme` | type | `"light" \| "dark"` |
+| `ThemeContextValue` | type | Return type of `useTheme()` |
+| `ThemeProviderProps` | type | Props for `ThemeProvider` |
+| `ThemeToggleProps` | type | Props for `ThemeToggle` |
+
+---
+
+## Accessibility notes
+
+- **Respects `prefers-color-scheme` by default.** When `preference === "system"`, the runtime subscribes to the media query and updates on OS theme changes — you don't need to do anything.
+- **`ThemeToggle` has a descriptive accessible label.** The default label is `"Current theme: {Light|Dark|System}. Click to cycle."` — screen reader users learn the current state and the interaction in one announcement.
+- **No focus flash.** Because theme switching is a single attribute change on `<html>`, focus rings and component state don't flicker.
+- **No JS required for visual theming.** If JS is disabled, the page renders with the `:root` (light) theme and remains fully usable. Only the toggle and preference persistence require JS.
+- **Respect `prefers-reduced-motion`.** The runtime itself doesn't animate, but custom themes should ensure transitions on `color`/`background-color` honor the user's reduced-motion preference.
+
+---
+
+## See also
+
+- [Design Tokens Guide](./design-tokens.md) — the underlying JSON artifact that powers every theme
+- [CSS Variables Guide](./css-variables.md) — which CSS variables get overridden in dark mode
+- [Accessibility Guide](./accessibility.md) — color contrast rules for custom themes
+- [Foundations/Colors page](../../../../apps/astro-builds/src/pages/foundations/colors.astro) — live view of every color token in light and dark


### PR DESCRIPTION
## Summary

- Root README was pinned on v0.5.11 and the package docs had no mention of Phase 2–7A work (theming runtime, design-token pipeline, Astro docs site, maturity dashboard, CI quality gates, IconButton/Fieldset). Both READMEs now describe the current v6.5 surface.
- Two new guides cover the theming runtime and the DTCG token artifact in depth, mirroring the existing guide pattern in `packages/fpkit/docs/guides/`.
- CHANGELOG.md files were intentionally left untouched — Changesets owns them now (Phase 5).

## Files changed

| File | Change |
|---|---|
| `README.md` | New "What's New in v6.x"; Theming, Design Tokens, Docs Site & Component Maturity sections; CI Quality Gates subsection; Node 22.12 prereq; IconButton/Fieldset/Button xl-2xl/Dialog icon in component list; Monorepo structure notes Changesets |
| `packages/fpkit/README.md` | Theming Runtime + Design Tokens subsections under Styling & Theming; IconButton and Fieldset snippets in Core Components; Component Maturity dashboard pointer |
| `packages/fpkit/docs/guides/theming.md` (new) | `ThemeProvider`, `useTheme`, `ThemeToggle`, `getThemeFoucScript` with Astro/Next.js/Remix recipes; custom-theme workflow; API reference; a11y notes |
| `packages/fpkit/docs/guides/design-tokens.md` (new) | DTCG JSON shape verified against the built `libs/tokens.json` (129 tokens, per-token dark-mode overrides via `$extensions.com.fpkit.themeModes.dark`); Style Dictionary pipeline; consumption patterns for docs sites and Figma bridges |
| `packages/fpkit/docs/README.md` | Theming/Design Tokens/Component Lifecycle guide entries; workflow updates; docs version 1.1.0; Astro dashboard and Foundations page pointers |
| `.claude/launch.json` | `astro-demo` uses `autoPort: true` so concurrent worktree previews don't collide on port 4327 |
| `docs/planning/sync-readme-and-docs-with-v6.md` (new) | Approved plan file for this task |

## Why this matters

A visitor landing on the repo today sees a README describing v0.5.11 features, which misrepresents a package that's been through six phases of major work. Anyone looking for theming, tokens, or the docs-site dashboard had no discoverable entry point. These changes close that gap without adding new surfaces the library doesn't already ship.

## Verification

- **Link check:** 107/108 relative links in modified docs resolve. One pre-existing broken link (`packages/fpkit/README.md → CONTRIBUTING.md`) is out of scope.
- **Symbol accuracy:** Theming exports verified against `packages/fpkit/src/components/theme/index.ts`; tokens shape verified against the built `libs/tokens.json` after running `npm run tokens:build`.
- **Stale string sweep:** No remaining `v0.5.11` or `Node.js >= 20` strings in either README.

## Test plan

- [ ] Skim root README — verify Theming/Design Tokens/Docs Site sections read naturally
- [ ] Skim `packages/fpkit/README.md` — confirm Theming Runtime and Design Tokens subsections are correctly placed under Styling & Theming
- [ ] Open `packages/fpkit/docs/guides/theming.md` — spot-check that code snippets match the current API
- [ ] Open `packages/fpkit/docs/guides/design-tokens.md` — confirm the shape description matches `packages/fpkit/libs/tokens.json` after a local build
- [ ] Confirm `packages/fpkit/docs/README.md` guide index links resolve in GitHub's markdown renderer

## Follow-ups (out of scope)

- `npm run build` in `packages/fpkit` silently skips `tokens:build` inside the `run-s` chain but works when invoked directly — worth investigating.
- Many `MIGRATION-*.md` files could be consolidated into a single migration index.
- `docs/planning/` has several auto-named files (`crispy-sprouting-clock.md`, etc.) that the `plan-hygiene` skill could rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)