### PR TITLE
chore(release): publish @fpkit/acss@6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to @fpkit/acss will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.6.0] - 2026-04-18
+
+### Added
+
+- **Design token pipeline** — Style Dictionary build pipeline extracts 129 tokens from SCSS into `libs/tokens.json` and `src/tokens/index.ts`
+- **ThemeProvider + ThemeToggle** — light/dark/system theme runtime with `localStorage` persistence and FOUC-prevention script
+- **Dialog `size` and `position` props** — modal sizing and placement control (center, top, bottom, etc.)
+- **Dialog type exports** — `DialogProps` and `DialogModalProps` now exported from the package index
+- **acss-kit-builder plugin** — standalone Claude Code plugin for generating fpkit-style components without the full library dependency
+- **Astro docs site scaffold** — Phase 6 Astro documentation site foundation
+- **Component maturity dashboard** — Phase 7A governance tooling for tracking component readiness
+- **CI quality gates** — coverage thresholds, bundle size checks, and a11y gate via axe + Storybook test-runner
+
+### Fixed
+
+- **Storybook 10 migration** — config updated and dialog stories types corrected
+- **Chromatic CI** — skips cleanly when `CHROMATIC_PROJECT_TOKEN` is unset
+- **a11y CI gate** — non-blocking axe integration; 4 interaction-test failures repaired
+- **Dialog centering** — modal now centers by default with `fit-content` height
+
+---
+
 ## [6.4.3] - 2026-03-07
 
 ### Fixed

--- a/apps/astro-builds/CHANGELOG.md
+++ b/apps/astro-builds/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.4.0](https://github.com/shawn-sandy/acss/compare/astro-fpkit@1.2.2...astro-fpkit@1.4.0) (2026-04-18)
+
+
+### Features
+
+* **design-system:** Phase 6 — Astro docs site scaffold ([01f926f](https://github.com/shawn-sandy/acss/commit/01f926fa2e8cb512476ee58fceb25f62543e7bc9))
+* **design-system:** Phase 7A — component maturity dashboard ([2f51db1](https://github.com/shawn-sandy/acss/commit/2f51db13c7fdd6ba4e02844688665f8de24b81e9)), closes [#146](https://github.com/shawn-sandy/acss/issues/146)
+* **dialog:** add size and position props for modal sizing and placement ([33d5cde](https://github.com/shawn-sandy/acss/commit/33d5cde587a9cf15db6e80f288dae928bd9a858e))
+
+
+
+
+
 # [1.3.0](https://github.com/shawn-sandy/acss/compare/astro-fpkit@1.2.2...astro-fpkit@1.3.0) (2026-03-08)
 
 

--- a/apps/astro-builds/package-lock.json
+++ b/apps/astro-builds/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-fpkit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-fpkit",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@astrojs/react": "^4.1.2",
         "@fpkit/acss": "file:../../packages/fpkit",

--- a/apps/astro-builds/package.json
+++ b/apps/astro-builds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-fpkit",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "ensure-fpkit-build": "test -f ../../packages/fpkit/libs/index.js && test -f ../../packages/fpkit/libs/tokens.json || npm --prefix ../../packages/fpkit run build",

--- a/packages/fpkit/CHANGELOG.md
+++ b/packages/fpkit/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.6.0](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.6.0) (2026-04-18)
+
+
+### Bug Fixes
+
+* **ci:** skip Chromatic cleanly when CHROMATIC_PROJECT_TOKEN is unset ([9efd87d](https://github.com/shawn-sandy/fpkit/commit/9efd87d924f376d1e4b275575f716cb20fd0b6fb))
+* **ci:** wire axe into Storybook test-runner and non-block a11y gate ([125a393](https://github.com/shawn-sandy/fpkit/commit/125a39385efb33b30acd326dcd7e1fa014ce748e))
+* **design-system:** address PR [#145](https://github.com/shawn-sandy/fpkit/issues/145) review feedback ([a910017](https://github.com/shawn-sandy/fpkit/commit/a910017f1202f8f9f0002c074fc8f133bf566300))
+* **dialog:** default position to center and update stories with position assertions ([d634f5d](https://github.com/shawn-sandy/fpkit/commit/d634f5dc41ac68b96c7401d5a3fd8bc233c761c8))
+* **dialog:** ensure modal centers by default with fit-content height ([36517f7](https://github.com/shawn-sandy/fpkit/commit/36517f7009c5cb9d6b4b9245a49c6e64105dfa08))
+* **dialog:** export DialogModal from package index ([269a245](https://github.com/shawn-sandy/fpkit/commit/269a245ffa1f1f5922427a07eb8c5c0219b57a8b))
+* **dialog:** format export of DialogProps and DialogModalProps types ([94d6898](https://github.com/shawn-sandy/fpkit/commit/94d689856d51b6b01e069a965b69e7c407f84760))
+* **plugin:** address PR [#142](https://github.com/shawn-sandy/fpkit/issues/142) review issues in ui.tsx and acss-kit-builder ([a54eba1](https://github.com/shawn-sandy/fpkit/commit/a54eba1d0106cc742a842b751a3881ba659552a2))
+* **stories:** repair 4 interaction-test failures surfacing in a11y job ([f4fd934](https://github.com/shawn-sandy/fpkit/commit/f4fd93477ca3e93bd4c74a77a9b067bd3271c08b)), closes [#145](https://github.com/shawn-sandy/fpkit/issues/145)
+* **storybook:** migrate config to Storybook 10 and fix dialog stories types ([5833106](https://github.com/shawn-sandy/fpkit/commit/5833106cee8404527e140b66a4b3f67a073ca703))
+
+
+### Features
+
+* **design-system:** Phase 1 — governance docs and theme-ready color tokens ([3a290db](https://github.com/shawn-sandy/fpkit/commit/3a290dbccd5093b92ff811b261e7b5f6d3132aea))
+* **design-system:** Phase 2 — design token pipeline ([f8496ef](https://github.com/shawn-sandy/fpkit/commit/f8496efaad06c0255792cc8474c719277296a2d7))
+* **design-system:** Phase 3 — theming runtime with light/dark support ([6e9dfc6](https://github.com/shawn-sandy/fpkit/commit/6e9dfc6e7d6f8a93c1828811e04fd4ede3f902bb))
+* **design-system:** Phase 4 — component completion and v7 migration scaffold ([56b8334](https://github.com/shawn-sandy/fpkit/commit/56b833448bf74956e05e8bca53d07ba6be7da817))
+* **design-system:** Phase 5 — CI quality gates (coverage, size, release) ([dcb7c22](https://github.com/shawn-sandy/fpkit/commit/dcb7c22f1172597a21a4c6d499dc34d81e8a1bd2))
+* **design-system:** Phase 7A — component maturity dashboard ([2f51db1](https://github.com/shawn-sandy/fpkit/commit/2f51db13c7fdd6ba4e02844688665f8de24b81e9)), closes [#146](https://github.com/shawn-sandy/fpkit/issues/146)
+* **dialog:** add size and position props for modal sizing and placement ([33d5cde](https://github.com/shawn-sandy/fpkit/commit/33d5cde587a9cf15db6e80f288dae928bd9a858e))
+* **dialog:** export DialogProps and DialogModalProps types from package index ([434c0cf](https://github.com/shawn-sandy/fpkit/commit/434c0cf9d41eda837878747ea965339df35e1025))
+
+
+
+
+
 # [6.5.0](https://github.com/shawn-sandy/fpkit/compare/@fpkit/acss@6.4.0...@fpkit/acss@6.5.0) (2026-03-08)
 
 

--- a/packages/fpkit/package-lock.json
+++ b/packages/fpkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fpkit/acss",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fpkit/acss",
-      "version": "6.5.0",
+      "version": "6.6.0",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/packages/fpkit/package.json
+++ b/packages/fpkit/package.json
@@ -2,7 +2,7 @@
   "name": "@fpkit/acss",
   "description": "A lightweight React UI library for building modern and accessible components that leverage CSS custom properties for reactive Styles.",
   "private": false,
-  "version": "6.5.0",
+  "version": "6.6.0",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.0.0"

--- a/packages/fpkit/src/test/setup.ts
+++ b/packages/fpkit/src/test/setup.ts
@@ -3,6 +3,27 @@ import '@testing-library/jest-dom'
 import matchers from '@testing-library/jest-dom/matchers';
 import { expect, beforeAll } from 'vitest';
 
+// Vitest 0.33 ships a localStorage stub that omits clear() — replace with a
+// full in-memory Storage implementation so tests can call localStorage.clear()
+const makeStorage = () => {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null,
+    setItem: (key: string, value: string) => { store[key] = String(value); },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { for (const k in store) delete store[k]; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+};
+
+if (typeof window !== 'undefined') {
+  const localStorageMock = makeStorage();
+  const sessionStorageMock = makeStorage();
+  Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+  Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock, writable: true });
+}
+
 expect.extend(matchers);
 
 // Mock native <dialog> element methods for testing


### PR DESCRIPTION
## Release: @fpkit/acss@6.6.0

Minor version bump — new features since v6.5.0, no breaking changes.

## What's New

### Added
- **Design token pipeline** — Style Dictionary build pipeline; extracts 129 tokens into `libs/tokens.json` and `src/tokens/index.ts`
- **ThemeProvider + ThemeToggle** — light/dark/system theme runtime with `localStorage` persistence and FOUC-prevention inline script
- **Dialog `size` and `position` props** — modal sizing and placement control
- **Dialog type exports** — `DialogProps` and `DialogModalProps` now exported from the package index
- **acss-kit-builder plugin** — Claude Code plugin for generating fpkit-style components standalone
- **Astro docs site scaffold** (Phase 6) and **component maturity dashboard** (Phase 7A)
- **CI quality gates** — coverage thresholds, bundle size checks, axe a11y gate via Storybook test-runner

### Fixed
- **Storybook 10 migration** — config updated and dialog stories types corrected
- **Chromatic CI** — skips cleanly when `CHROMATIC_PROJECT_TOKEN` is unset
- **Dialog centering** — modal centers by default with `fit-content` height
- **Test setup** — polyfill `localStorage.clear()` for Vitest 0.33 jsdom compatibility (unblocks theme tests)

## Validation
- [x] Build passes (`run-s tokens:build package sass build:sass build:css`)
- [x] Lint passes (0 errors, 3 warnings)
- [x] Tests pass (1037/1037)
- [x] Version bumped: `6.5.0` → `6.6.0`

## Post-merge publish command
```bash
git checkout main && git pull
npx lerna publish from-package --yes --otp=<6-digit-OTP>
git push --follow-tags
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)