### PR TITLE
docs(design-system): document v6.x conversion with a11y + discoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/css-custom-data.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/css-custom-data.json
+++ b/.vscode/css-custom-data.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vscode-css-languageservice/main/docs/customData.schema.json",
+  "version": 1.1,
+  "properties": [
+    {
+      "name": "--color-primary",
+      "description": "Brand primary color. Inverts under [data-theme=\"dark\"]."
+    },
+    {
+      "name": "--color-secondary",
+      "description": "Brand secondary color."
+    },
+    {
+      "name": "--color-surface",
+      "description": "Default page/background surface."
+    },
+    {
+      "name": "--color-surface-elevated",
+      "description": "Elevated surface (cards, popovers)."
+    },
+    {
+      "name": "--color-text",
+      "description": "Primary body text color."
+    },
+    {
+      "name": "--color-text-secondary",
+      "description": "Secondary text (descriptions, captions)."
+    },
+    {
+      "name": "--color-text-inverse",
+      "description": "Text color on dark surfaces (buttons, chips)."
+    },
+    {
+      "name": "--color-error",
+      "description": "Error / danger semantic color."
+    },
+    {
+      "name": "--color-success",
+      "description": "Success semantic color."
+    },
+    {
+      "name": "--color-warning",
+      "description": "Warning semantic color."
+    },
+    {
+      "name": "--color-info",
+      "description": "Info semantic color."
+    },
+    {
+      "name": "--color-ui-overlay-base",
+      "description": "RGB triplet for composing hover/active overlays via rgba(). Inverts under dark mode (0,0,0 light; 255,255,255 dark)."
+    },
+    {
+      "name": "--color-hover-overlay",
+      "description": "Prebuilt hover overlay, theme-aware. Use instead of hard-coded rgba(0,0,0,…)."
+    },
+    {
+      "name": "--color-active-overlay",
+      "description": "Prebuilt active/pressed overlay, theme-aware."
+    },
+    {
+      "name": "--color-border-subtle",
+      "description": "Low-contrast border for dividers and outlines."
+    },
+    {
+      "name": "--color-link",
+      "description": "Link color. Distinct from --color-primary."
+    },
+    {
+      "name": "--color-focus",
+      "description": "Focus ring color."
+    },
+    {
+      "name": "--duration-instant",
+      "description": "Motion token — 0ms (essentially immediate). Added in Phase 2 token pipeline."
+    },
+    {
+      "name": "--duration-fast",
+      "description": "Motion token — short transitions (hover, small state changes)."
+    },
+    {
+      "name": "--duration-base",
+      "description": "Motion token — default transition duration for most UI changes."
+    },
+    {
+      "name": "--duration-slow",
+      "description": "Motion token — larger elements entering or leaving."
+    },
+    {
+      "name": "--duration-slower",
+      "description": "Motion token — full-page transitions."
+    },
+    {
+      "name": "--ease-standard",
+      "description": "Motion easing — default curve for most transitions."
+    },
+    {
+      "name": "--ease-accelerate",
+      "description": "Motion easing — for elements leaving the screen."
+    },
+    {
+      "name": "--ease-decelerate",
+      "description": "Motion easing — for elements entering the screen."
+    },
+    {
+      "name": "--ease-emphasized",
+      "description": "Motion easing — for attention-grabbing transitions."
+    },
+    {
+      "name": "--breakpoint-reflow",
+      "description": "Responsive breakpoint (20rem / 320px) — WCAG reflow minimum."
+    },
+    {
+      "name": "--breakpoint-xs",
+      "description": "Responsive breakpoint (23.4375rem / 375px) — iPhone SE class."
+    },
+    {
+      "name": "--breakpoint-sm",
+      "description": "Responsive breakpoint (30rem / 480px) — small phones upright."
+    },
+    {
+      "name": "--breakpoint-md",
+      "description": "Responsive breakpoint (48rem / 768px) — tablets."
+    },
+    {
+      "name": "--breakpoint-lg",
+      "description": "Responsive breakpoint (62rem / 992px) — desktops."
+    },
+    {
+      "name": "--breakpoint-xl",
+      "description": "Responsive breakpoint (80rem / 1280px) — large screens."
+    },
+    {
+      "name": "--breakpoint-2xl",
+      "description": "Responsive breakpoint (96rem / 1536px) — very large screens."
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "css.customData": [".vscode/css-custom-data.json"],
+  "scss.customData": [".vscode/css-custom-data.json"],
+  "css.lint.unknownProperties": "ignore"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ The docs themselves must meet the same accessibility bar as the components — W
 
 - [ ] **Semantic HTML** — use `<main>`, `<nav>`, `<article>`, `<aside>`. Reuse the fpkit `Layout`, `Header`, `Main`, `Footer` components where applicable.
 - [ ] **One `<h1>` per page** — followed by a logical heading outline. Verify in DevTools → Accessibility tree.
-- [ ] **Skip link reachable on first tab** — the `Layout.astro` ships one; don't break it. Test with keyboard only.
+- [ ] **Skip link reachable on first tab** — `SiteHeader.tsx` renders it; don't break it. Test with keyboard only.
 - [ ] **Visible focus indicators** — never suppress `:focus-visible`. Tab through every interactive element; confirm a ring is visible in both light and dark themes.
 - [ ] **Color contrast ≥ 4.5:1 in both themes** — run axe DevTools extension with `data-theme="light"` and `data-theme="dark"`. Pay special attention to label text over color swatches (Foundations pages) and lifecycle pills (Status page).
 - [ ] **Keyboard-only pass** — no keyboard traps, tab order matches visual order, every interactive element reachable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for considering a contribution. This guide covers how to propose chang
 - [Development Workflow](#development-workflow)
 - [Commit Conventions](#commit-conventions)
 - [Style, Testing, and Accessibility Bars](#style-testing-and-accessibility-bars)
+- [Docs accessibility checklist](#docs-accessibility-checklist)
 - [Release Process](#release-process)
 
 ---
@@ -89,6 +90,58 @@ Breaking changes get `!` and a `BREAKING CHANGE:` footer: `feat(alert)!: rename 
 - **Variants**: follow `.claude/rules/component-conventions.md` — `data-{component}` for size/layout, `data-style` for appearance, `data-color` for semantic intent. See `packages/fpkit/docs/guides/variants.md` for the prop-vs-attribute policy.
 
 See `packages/fpkit/docs/guides/` for deep-dives on accessibility, architecture, composition, testing, CSS variables, and Storybook.
+
+## Docs accessibility checklist
+
+The docs themselves must meet the same accessibility bar as the components — WCAG 2.1 AA. Before opening a PR that adds or modifies documentation (markdown files, Astro pages, or component-level READMEs), run through this checklist.
+
+### Markdown (applies to every `.md` file)
+
+- [ ] **Heading hierarchy** — no skipped levels. Each page has exactly one `#` title; subsequent headings follow `##` → `###` in order. Validate with `markdownlint` rule `MD001`.
+- [ ] **Alt text on every image** — including decorative images (`alt=""`). No image-only content.
+- [ ] **Descriptive link text** — no "click here" or "read more"; use "See the theming guide" style. Screen-reader users navigate by link list.
+- [ ] **Code fences specify a language** — `~~~tsx`, `~~~scss`, `~~~bash`. Enables syntax highlighting and helps assistive tech identify code blocks.
+- [ ] **Tables have header rows** — use `| --- | --- |` syntax so screen readers announce column context.
+- [ ] **Color isn't the only signal** — if you use emoji or color to convey status, pair it with text (e.g. `✅ shipped`, not just `✅`).
+
+### Astro docs site (`apps/astro-builds/`)
+
+- [ ] **Semantic HTML** — use `<main>`, `<nav>`, `<article>`, `<aside>`. Reuse the fpkit `Layout`, `Header`, `Main`, `Footer` components where applicable.
+- [ ] **One `<h1>` per page** — followed by a logical heading outline. Verify in DevTools → Accessibility tree.
+- [ ] **Skip link reachable on first tab** — the `Layout.astro` ships one; don't break it. Test with keyboard only.
+- [ ] **Visible focus indicators** — never suppress `:focus-visible`. Tab through every interactive element; confirm a ring is visible in both light and dark themes.
+- [ ] **Color contrast ≥ 4.5:1 in both themes** — run axe DevTools extension with `data-theme="light"` and `data-theme="dark"`. Pay special attention to label text over color swatches (Foundations pages) and lifecycle pills (Status page).
+- [ ] **Keyboard-only pass** — no keyboard traps, tab order matches visual order, every interactive element reachable.
+- [ ] **`prefers-reduced-motion`** — if you add transitions, wrap them in `@media (prefers-reduced-motion: no-preference)`.
+- [ ] **No hardcoded colors** — use semantic tokens (`var(--color-text)`, `var(--color-surface)`) so dark mode works automatically.
+
+### Component READMEs (`.mdx`)
+
+- [ ] All of the markdown items above, plus:
+- [ ] **Code examples compile** — every snippet should be copy-pasteable and type-check against the current component API.
+- [ ] **JSX examples include `import` statements** — readers copying the snippet don't have to guess the export name.
+
+### Verification commands
+
+```bash
+# Markdown lint (install once: npm i -g markdownlint-cli)
+markdownlint packages/fpkit/docs/**/*.md packages/fpkit/MIGRATION-v7.md
+
+# Broken link check
+npx markdown-link-check packages/fpkit/docs/**/*.md
+
+# Astro build — catches type errors in .astro files
+cd apps/astro-builds && npm run build
+
+# Manual axe pass on the built docs site
+# 1. Install axe DevTools extension (Chrome/Firefox)
+# 2. npm run dev (or npm run preview after build)
+# 3. Run axe on every page in both light and dark themes
+```
+
+If you find a violation in *existing* docs during your PR, file a follow-up issue rather than blocking merge — unless the violation is in code you directly touched.
+
+> **Planned CI gate:** a `@axe-core/cli` check against the built Astro docs site is on the roadmap. Until it lands, this checklist is the contract. See the [CI Gates guide](packages/fpkit/docs/guides/ci-gates.md#docs-site-gate--planned).
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ A lightweight React UI component library for building modern and accessible appl
 
 [![npm version](https://img.shields.io/npm/v/@fpkit/acss.svg)](https://www.npmjs.com/package/@fpkit/acss)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Docs site](https://img.shields.io/badge/docs-astro-ff5d01.svg)](apps/astro-builds/)
+[![Design system v6](https://img.shields.io/badge/design--system-v6-blueviolet.svg)](packages/fpkit/docs/DESIGN-SYSTEM-v6.md)
+
+## Design system
+
+`@fpkit/acss` ships a complete design system as of v6.x: tokens, theming, CI quality gates, and a public docs site.
+
+- 📖 **[Design System v6 Overview](packages/fpkit/docs/DESIGN-SYSTEM-v6.md)** — narrative of everything that shipped in v6.x.
+- 🗺️ **[Documentation index](packages/fpkit/docs/README.md)** — one-line-per-guide directory of all 13 guides.
+- ⬆️ **[Upgrade guide](packages/fpkit/MIGRATION-v7.md#minimum-viable-v6x-upgrade)** — five-step minimum-viable upgrade path.
+- 🎨 **[Astro docs site](apps/astro-builds/)** — live Foundations pages and `/status` maturity dashboard.
 
 ## Features
 
@@ -83,7 +94,7 @@ function App() {
 
 ## What's New in v6.x
 
-Major additions since `1.0.0-beta.0` (CSS-variable rename — see [MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md)):
+See the [Design System v6 Overview](packages/fpkit/docs/DESIGN-SYSTEM-v6.md) for the full narrative. Major additions since `1.0.0-beta.0` (CSS-variable rename — see [MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md)):
 
 - **Theming runtime** — `ThemeProvider`, `useTheme`, `ThemeToggle`, and `getThemeFoucScript()` for SSR. Light/dark via a single `data-theme` attribute on `<html>`; system-preference tracking built in. See the [Theming guide](packages/fpkit/docs/guides/theming.md).
 - **Design token pipeline** — `@fpkit/acss/tokens` ships a DTCG-compliant JSON artifact with primitive and semantic colors (plus per-token dark-mode overrides), motion durations and easings, and responsive breakpoints. Ready for Figma bridges, docs sites, and custom builds. Typography and spacing tokens are on the roadmap. See the [Design Tokens guide](packages/fpkit/docs/guides/design-tokens.md).
@@ -248,12 +259,13 @@ npm run version-packages # Apply changesets and bump versions
 
 ### CI Quality Gates
 
-Contributors should know what the CI enforces before opening a PR:
+Contributors should know what the CI enforces before opening a PR. Full details in the [CI Gates guide](packages/fpkit/docs/guides/ci-gates.md):
 
-- **Test coverage thresholds** — configured in [packages/fpkit/vitest.config.js](packages/fpkit/vitest.config.js); failing below ~89% lines / 90% branches breaks the test job.
-- **Bundle-size budgets** — [packages/fpkit/.size-limit.cjs](packages/fpkit/.size-limit.cjs) caps the main build, hooks, icons, and CSS entry points. `npm run size` reports against the budget.
-- **Accessibility audit** — the Storybook test-runner wires axe via [.storybook/test-runner.ts](.storybook/test-runner.ts). Non-blocking during triage; flipping to blocking is tracked in [MIGRATION-v7.md](packages/fpkit/MIGRATION-v7.md).
-- **Versioning** — Changesets owns `CHANGELOG.md` and version bumps. Hand-edits to `CHANGELOG.md` will be clobbered on the next release.
+- **Test coverage thresholds** — lines 89%, branches 90%, functions 66%, statements 89% ([vitest.config.js](packages/fpkit/vitest.config.js)).
+- **Bundle-size budgets** — main 18 KB, hooks 3 KB, icons 6 KB, CSS 18 KB gzipped ([.size-limit.cjs](packages/fpkit/.size-limit.cjs)). Run `npm run size` to check locally.
+- **Accessibility audit** — Storybook test-runner + axe. Non-blocking during triage; [flip criteria documented](packages/fpkit/docs/guides/ci-gates.md#flipping-to-blocking).
+- **Visual regression** — Chromatic, gated on `CHROMATIC_PROJECT_TOKEN` secret.
+- **Versioning** — Changesets owns `CHANGELOG.md` and version bumps. Hand-edits will be clobbered on the next release.
 
 ## TypeScript Support
 

--- a/apps/astro-builds/astro.config.mjs
+++ b/apps/astro-builds/astro.config.mjs
@@ -2,7 +2,24 @@
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 
+/**
+ * To enable the sitemap integration (planned for discoverability of the
+ * /guides/ pages once the deploy-docs URL is finalized):
+ *
+ *   1. npm install -D @astrojs/sitemap
+ *   2. Uncomment the import + integration line below.
+ *   3. Set `site` to the canonical docs URL once it's live.
+ *
+ * Until then, <link rel="canonical"> in Layout.astro handles search-engine
+ * authority scoping without a sitemap.
+ */
+// import sitemap from "@astrojs/sitemap";
+
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react()],
+  // site: "https://fpkit.example.com",  // set once deploy-docs URL is finalized
+  integrations: [
+    react(),
+    // sitemap(),
+  ],
 });

--- a/apps/astro-builds/src/components/SiteHeader.tsx
+++ b/apps/astro-builds/src/components/SiteHeader.tsx
@@ -16,7 +16,7 @@ import { ThemeProvider, ThemeToggle } from "@fpkit/acss";
 const NAV = [
   { href: "/", label: "Home" },
   { href: "/foundations/colors", label: "Foundations" },
-  { href: "/guides/design-principles", label: "Guides" },
+  { href: "/guides/", label: "Guides" },
   { href: "/status", label: "Status" },
 ];
 

--- a/apps/astro-builds/src/layouts/Layout.astro
+++ b/apps/astro-builds/src/layouts/Layout.astro
@@ -28,11 +28,15 @@ const {
 // Cache the FOUC script string once at build time.
 const foucScript = getThemeFoucScript();
 
-// Canonical URL — keeps search engines from splitting authority across any
-// alternate origins (GitHub Pages + custom domain, preview deployments, etc.).
-// Astro.url includes the current path; Astro.site is the canonical origin
-// declared in astro.config.mjs (falls back to the request origin when unset).
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toString();
+// Canonical URL — only emit when `site` is explicitly configured in
+// astro.config.mjs. Without that, Astro.url falls back to the serving host
+// (Netlify preview subdomain, localhost during `astro build`, etc.), which
+// would publish misleading canonical/og:url values and fragment search
+// authority. Once the production URL is decided, set `site` in astro.config
+// and these tags will appear automatically.
+const canonicalUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : null;
 ---
 
 <!doctype html>
@@ -42,13 +46,13 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toStri
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="canonical" href={canonicalUrl} />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     <meta name="generator" content={Astro.generator} />
     {/* Open Graph — helps link previews in Slack, GitHub, etc. */}
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content={canonicalUrl} />
+    {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
     <title>{title}</title>
     {/* FOUC guard — must run before any styles apply so data-theme is set on <html>. */}
     <script is:inline set:html={foucScript} />

--- a/apps/astro-builds/src/layouts/Layout.astro
+++ b/apps/astro-builds/src/layouts/Layout.astro
@@ -27,6 +27,12 @@ const {
 
 // Cache the FOUC script string once at build time.
 const foucScript = getThemeFoucScript();
+
+// Canonical URL — keeps search engines from splitting authority across any
+// alternate origins (GitHub Pages + custom domain, preview deployments, etc.).
+// Astro.url includes the current path; Astro.site is the canonical origin
+// declared in astro.config.mjs (falls back to the request origin when unset).
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toString();
 ---
 
 <!doctype html>
@@ -36,7 +42,13 @@ const foucScript = getThemeFoucScript();
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href={canonicalUrl} />
     <meta name="generator" content={Astro.generator} />
+    {/* Open Graph — helps link previews in Slack, GitHub, etc. */}
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl} />
     <title>{title}</title>
     {/* FOUC guard — must run before any styles apply so data-theme is set on <html>. */}
     <script is:inline set:html={foucScript} />

--- a/apps/astro-builds/src/pages/guides/index.astro
+++ b/apps/astro-builds/src/pages/guides/index.astro
@@ -1,0 +1,254 @@
+---
+/**
+ * Guides landing page.
+ *
+ * The full-length guides live in `packages/fpkit/docs/guides/` as markdown;
+ * these Astro pages surface the high-value ones (theming, tokens, migration)
+ * to the public docs site so consumers don't have to dig into the repo.
+ *
+ * Design note on accessibility: every card is an <a> wrapping the title, not
+ * a <div> with a button inside. Screen-reader users navigate the site by link
+ * list; wrapping the whole card surface keeps the click target generous
+ * without breaking that navigation model.
+ */
+import Layout from "../../layouts/Layout.astro";
+
+type GuideCard = {
+  title: string;
+  description: string;
+  href: string;
+  source: string;
+  audience: "Consumers" | "Contributors" | "Both";
+};
+
+const GUIDES: GuideCard[] = [
+  {
+    title: "Theming",
+    description:
+      "ThemeProvider, useTheme, ThemeToggle, and the FOUC script — ship light/dark without a flash on first paint.",
+    href: "/guides/theming",
+    source: "packages/fpkit/docs/guides/theming.md",
+    audience: "Consumers",
+  },
+  {
+    title: "Design tokens",
+    description:
+      "The @fpkit/acss/tokens artifact — DTCG JSON plus a typed TS module. Patterns for Figma, Astro, and cross-platform consumers.",
+    href: "/guides/tokens",
+    source: "packages/fpkit/docs/guides/design-tokens.md",
+    audience: "Consumers",
+  },
+  {
+    title: "Migration to v7",
+    description:
+      "Per-change upgrade steps with before/after React + SCSS snippets. Starts with a 5-step minimum-viable upgrade.",
+    href: "/guides/migration",
+    source: "packages/fpkit/MIGRATION-v7.md",
+    audience: "Consumers",
+  },
+  {
+    title: "Design system v6 overview",
+    description:
+      "The full narrative of what shipped across Phases 1–7A — tokens, theming, CI gates, Astro site, maturity dashboard.",
+    href: "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/DESIGN-SYSTEM-v6.md",
+    source: "packages/fpkit/docs/DESIGN-SYSTEM-v6.md",
+    audience: "Both",
+  },
+];
+
+const CONTRIBUTOR_GUIDES = [
+  {
+    title: "CI quality gates",
+    description:
+      "Coverage thresholds, bundle-size budgets, a11y gate, Chromatic, release flow.",
+    href: "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/ci-gates.md",
+  },
+  {
+    title: "Component maturity dashboard",
+    description:
+      "How the /status page derives signals from Storybook meta. Tagging conventions.",
+    href: "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/maturity-dashboard.md",
+  },
+  {
+    title: "Component lifecycle",
+    description:
+      "Promotion criteria for experimental → beta → rc → stable → deprecated.",
+    href: "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/component-lifecycle.md",
+  },
+  {
+    title: "Accessibility",
+    description: "The WCAG 2.1 AA patterns that the components implement.",
+    href: "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/accessibility.md",
+  },
+];
+---
+
+<Layout
+  title="Guides — @fpkit/acss"
+  description="Consumer + contributor guides for the @fpkit/acss design system."
+>
+  <article>
+    <header class="page-intro">
+      <h1>Guides</h1>
+      <p>
+        Task-oriented guides for consuming and contributing to
+        <code>@fpkit/acss</code>. Looking for the full <a
+          href="https://github.com/shawn-sandy/acss/tree/main/packages/fpkit/docs"
+          >markdown source</a
+        >? It lives in the repo.
+      </p>
+    </header>
+
+    <section aria-labelledby="consumer-heading">
+      <h2 id="consumer-heading">For library consumers</h2>
+      <ul class="guide-grid" role="list">
+        {
+          GUIDES.map((guide) => (
+            <li class="guide-card">
+              <a href={guide.href} class="guide-card__link">
+                <h3 class="guide-card__title">{guide.title}</h3>
+              </a>
+              <p class="guide-card__description">{guide.description}</p>
+              <p class="guide-card__source">
+                <span class="guide-card__audience">{guide.audience}</span>
+                <span class="guide-card__sep" aria-hidden="true">·</span>
+                <span class="guide-card__path">{guide.source}</span>
+              </p>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section aria-labelledby="contributor-heading">
+      <h2 id="contributor-heading">For contributors</h2>
+      <p>
+        Guides for working <em>on</em> the library itself — CI gates, component
+        promotion criteria, accessibility patterns.
+      </p>
+      <ul class="guide-grid" role="list">
+        {
+          CONTRIBUTOR_GUIDES.map((guide) => (
+            <li class="guide-card">
+              <a href={guide.href} class="guide-card__link">
+                <h3 class="guide-card__title">{guide.title}</h3>
+              </a>
+              <p class="guide-card__description">{guide.description}</p>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <aside class="see-also" aria-labelledby="see-also-heading">
+      <h2 id="see-also-heading">See also</h2>
+      <ul>
+        <li><a href="/foundations/colors">Foundations — color tokens</a></li>
+        <li><a href="/foundations/typography">Foundations — typography</a></li>
+        <li><a href="/foundations/spacing">Foundations — spacing</a></li>
+        <li><a href="/foundations/motion">Foundations — motion</a></li>
+        <li><a href="/status">Component maturity dashboard</a></li>
+      </ul>
+    </aside>
+  </article>
+
+  <style>
+    .page-intro {
+      margin-block-end: 2rem;
+    }
+    .page-intro h1 {
+      margin-block: 0 0.5rem;
+    }
+    .page-intro p {
+      color: var(--color-text-secondary);
+      max-width: 48rem;
+      margin: 0;
+    }
+
+    section {
+      margin-block-end: 2.5rem;
+    }
+
+    .guide-grid {
+      list-style: none;
+      padding: 0;
+      margin: 1rem 0 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+      gap: 1rem;
+    }
+
+    .guide-card {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+    }
+
+    .guide-card__link {
+      color: var(--color-text);
+      text-decoration: none;
+    }
+    .guide-card__link:hover .guide-card__title,
+    .guide-card__link:focus-visible .guide-card__title {
+      color: var(--color-link);
+      text-decoration: underline;
+    }
+    .guide-card__link:focus-visible {
+      outline: 2px solid var(--color-focus, currentColor);
+      outline-offset: 2px;
+      border-radius: 0.25rem;
+    }
+
+    .guide-card__title {
+      margin: 0;
+      font-size: 1.125rem;
+      font-weight: 600;
+    }
+
+    .guide-card__description {
+      margin: 0;
+      color: var(--color-text-secondary);
+      font-size: 0.9375rem;
+      line-height: 1.5;
+    }
+
+    .guide-card__source {
+      margin: 0;
+      font-size: 0.75rem;
+      color: var(--color-text-tertiary);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    }
+
+    .guide-card__audience {
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 600;
+    }
+
+    .guide-card__sep {
+      margin-inline: 0.375rem;
+    }
+
+    .see-also {
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+    }
+    .see-also h2 {
+      margin-block: 0 0.5rem;
+      font-size: 1rem;
+    }
+    .see-also ul {
+      margin: 0;
+      padding-inline-start: 1.25rem;
+    }
+    .see-also a {
+      color: var(--color-link);
+    }
+  </style>
+</Layout>

--- a/apps/astro-builds/src/pages/guides/index.astro
+++ b/apps/astro-builds/src/pages/guides/index.astro
@@ -6,10 +6,10 @@
  * these Astro pages surface the high-value ones (theming, tokens, migration)
  * to the public docs site so consumers don't have to dig into the repo.
  *
- * Design note on accessibility: every card is an <a> wrapping the title, not
- * a <div> with a button inside. Screen-reader users navigate the site by link
- * list; wrapping the whole card surface keeps the click target generous
- * without breaking that navigation model.
+ * Design note on accessibility: each card exposes its title as a real <a>,
+ * rather than using a <div> with a button inside. Screen-reader users
+ * navigate the site by link list, so keeping the heading itself as the link
+ * preserves that navigation model while matching the current markup.
  */
 import Layout from "../../layouts/Layout.astro";
 

--- a/apps/astro-builds/src/pages/guides/migration.astro
+++ b/apps/astro-builds/src/pages/guides/migration.astro
@@ -1,0 +1,243 @@
+---
+/**
+ * Migration guide landing — the minimum-viable upgrade checklist surfaced
+ * on the docs site.
+ *
+ * Full per-change history (source of truth): packages/fpkit/MIGRATION-v7.md
+ * This page is intentionally short: 5 steps + the "what will break in v7"
+ * summary. Deep dives link to the repo markdown.
+ */
+import Layout from "../../layouts/Layout.astro";
+
+const MIGRATION_MD =
+  "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/MIGRATION-v7.md";
+
+const STEPS = [
+  {
+    title: "Bump the package",
+    body: `npm install @fpkit/acss@latest. Every change below is additive in v6.x — nothing breaks.`,
+  },
+  {
+    title: "Wrap your app in ThemeProvider",
+    body: `Render a ThemeToggle (or call useTheme() from your own picker). Every token-driven component picks up light/dark automatically.`,
+  },
+  {
+    title: "SSR only: inline getThemeFoucScript()",
+    body: `In your document <head>, before any styles load. Prevents the theme-flash on first paint. Works for Astro, Next.js, and Remix — the recipe differs, the script string is the same.`,
+  },
+  {
+    title: "Drop hand-coded hover/active overlays",
+    body: `Replace rgba(0, 0, 0, 0.08) with var(--color-hover-overlay) (and rgba(0, 0, 0, 0.16) with var(--color-active-overlay)). Your styles now flip correctly under dark mode.`,
+  },
+  {
+    title: "Migrate disabled-link logic",
+    body: `If you've rolled your own aria-disabled-on-link pattern, replace it with <Link disabled={!canEdit}>. You get keyboard-reachable disabled state (WCAG 2.1.1) for free.`,
+  },
+];
+---
+
+<Layout
+  title="Migration — @fpkit/acss guides"
+  description="Upgrade an existing @fpkit/acss app to the latest v6.x release in five steps."
+>
+  <article>
+    <header class="page-intro">
+      <p class="breadcrumb" aria-label="Breadcrumb">
+        <a href="/guides/">Guides</a>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Migration</span>
+      </p>
+      <h1>Migration</h1>
+      <p>
+        You're on an older v6.x and want to pick up theming + tokens today.
+        This is the absolute-minimum path. Every change is additive — if
+        you're green on this list, you're green for v7 too.
+      </p>
+    </header>
+
+    <section aria-labelledby="steps-heading">
+      <h2 id="steps-heading">Five-step upgrade</h2>
+      <ol class="step-list">
+        {
+          STEPS.map((step, i) => (
+            <li class="step">
+              <div class="step__number" aria-hidden="true">{i + 1}</div>
+              <div class="step__body">
+                <h3 class="step__title">{step.title}</h3>
+                <p class="step__text">{step.body}</p>
+              </div>
+            </li>
+          ))
+        }
+      </ol>
+    </section>
+
+    <section aria-labelledby="whats-coming">
+      <h2 id="whats-coming">What's coming in v7</h2>
+      <p>
+        v7.0.0 will bundle only the changes marked <span class="marker marker--break">💥</span>
+        in the full migration guide. Today there's one:
+      </p>
+      <ul>
+        <li>
+          <code>&lt;Heading&gt;</code> — deprecated since v6. Migrate to
+          <code>&lt;Title&gt;</code>. Prop rename is <code>type</code> →
+          <code>level</code>; nothing else changes.
+        </li>
+      </ul>
+      <p>
+        Everything else — tokens, theming, Button
+        <code>color="info"</code>, Link <code>disabled</code>, CSS overlay
+        tokens — already shipped in v6.x minors and will continue to work in
+        v7 unchanged.
+      </p>
+    </section>
+
+    <section aria-labelledby="status-legend">
+      <h2 id="status-legend">Status markers</h2>
+      <dl class="status-legend">
+        <div>
+          <dt><span class="marker marker--ship">✅</span></dt>
+          <dd>Shipped in a v6 minor. Additive; no action required.</dd>
+        </div>
+        <div>
+          <dt><span class="marker marker--warn">⚠️</span></dt>
+          <dd>Shipped in a v6 minor with a deprecation warning. Action required before v7.</dd>
+        </div>
+        <div>
+          <dt><span class="marker marker--break">💥</span></dt>
+          <dd>Will ship in v7.0.0. Breaking.</dd>
+        </div>
+      </dl>
+    </section>
+
+    <aside class="see-also" aria-labelledby="see-also">
+      <h2 id="see-also">See also</h2>
+      <ul>
+        <li>
+          <a href={MIGRATION_MD}
+            >Full migration guide on GitHub</a
+          > — every change with before/after code, plus the complete v7 breakage list.
+        </li>
+        <li><a href="/guides/theming">Theming quick-start</a></li>
+        <li><a href="/guides/tokens">Design tokens quick-start</a></li>
+        <li>
+          <a
+            href="https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/DESIGN-SYSTEM-v6.md"
+            >Design System v6 Overview</a
+          > — narrative of everything shipped in v6.x.
+        </li>
+      </ul>
+    </aside>
+  </article>
+
+  <style>
+    .page-intro {
+      margin-block-end: 2rem;
+    }
+    .breadcrumb {
+      margin: 0 0 0.5rem;
+      font-size: 0.875rem;
+      color: var(--color-text-tertiary);
+    }
+    .breadcrumb a {
+      color: var(--color-link);
+    }
+    .breadcrumb span[aria-current] {
+      color: var(--color-text);
+      font-weight: 600;
+    }
+    .page-intro p {
+      color: var(--color-text-secondary);
+      max-width: 48rem;
+    }
+    section {
+      margin-block-end: 2rem;
+    }
+    .step-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    .step {
+      display: flex;
+      gap: 1rem;
+      align-items: flex-start;
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+    }
+    .step__number {
+      flex: none;
+      width: 1.75rem;
+      height: 1.75rem;
+      display: grid;
+      place-items: center;
+      border-radius: 999px;
+      background: var(--color-primary);
+      color: var(--color-text-inverse);
+      font-weight: 700;
+      font-size: 0.875rem;
+    }
+    .step__title {
+      margin: 0 0 0.25rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .step__text {
+      margin: 0;
+      color: var(--color-text-secondary);
+      font-size: 0.9375rem;
+      line-height: 1.5;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--color-surface-elevated);
+      padding: 0.125rem 0.25rem;
+      border-radius: 0.25rem;
+    }
+    .marker {
+      display: inline-block;
+      margin-inline-end: 0.25rem;
+    }
+    .status-legend {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+    }
+    .status-legend > div {
+      display: flex;
+      gap: 0.75rem;
+      align-items: baseline;
+    }
+    .status-legend dt {
+      flex: none;
+      width: 2rem;
+      text-align: center;
+    }
+    .status-legend dd {
+      margin: 0;
+      color: var(--color-text-secondary);
+    }
+    .see-also {
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+    }
+    .see-also h2 {
+      margin-block: 0 0.5rem;
+      font-size: 1rem;
+    }
+    .see-also a {
+      color: var(--color-link);
+    }
+  </style>
+</Layout>

--- a/apps/astro-builds/src/pages/guides/theming.astro
+++ b/apps/astro-builds/src/pages/guides/theming.astro
@@ -1,0 +1,191 @@
+---
+/**
+ * Theming guide — condensed landing on the docs site.
+ *
+ * Full markdown (kept as source of truth): packages/fpkit/docs/guides/theming.md
+ * This page surfaces the quick-start path and the SSR gotcha most consumers
+ * hit; anything deeper links to GitHub.
+ */
+import Layout from "../../layouts/Layout.astro";
+
+const GITHUB_SOURCE =
+  "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/theming.md";
+---
+
+<Layout
+  title="Theming — @fpkit/acss guides"
+  description="Wire light/dark theming into your app with ThemeProvider, ThemeToggle, and getThemeFoucScript."
+>
+  <article>
+    <header class="page-intro">
+      <p class="breadcrumb" aria-label="Breadcrumb">
+        <a href="/guides/">Guides</a>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Theming</span>
+      </p>
+      <h1>Theming</h1>
+      <p>
+        Ship light/dark theming without a flash of the wrong colors on first
+        paint. Three primitives cover ~99% of apps: <code>ThemeProvider</code>,
+        <code>ThemeToggle</code>, and <code>getThemeFoucScript()</code> for SSR.
+      </p>
+    </header>
+
+    <section aria-labelledby="how-it-works">
+      <h2 id="how-it-works">How it works</h2>
+      <p>
+        The runtime sets <code>data-theme="light"</code> or
+        <code>data-theme="dark"</code> on <code>&lt;html&gt;</code>. Every
+        fpkit component that references semantic tokens flips immediately —
+        no re-render, no prop-drilling. Preference persists to
+        <code>localStorage</code>; "system" preference tracks
+        <code>prefers-color-scheme</code> at runtime.
+      </p>
+    </section>
+
+    <section aria-labelledby="quick-start">
+      <h2 id="quick-start">Quick start</h2>
+      <p>Client-only apps:</p>
+      <pre><code>{`import { ThemeProvider, ThemeToggle } from '@fpkit/acss';
+
+function App() {
+  return (
+    <ThemeProvider defaultPreference="system">
+      <header>
+        <ThemeToggle />
+      </header>
+      <main>{/* your app */}</main>
+    </ThemeProvider>
+  );
+}`}</code></pre>
+    </section>
+
+    <section aria-labelledby="ssr">
+      <h2 id="ssr">Preventing theme flash in SSR</h2>
+      <p>
+        For Astro, Next.js, or Remix, inline
+        <code>getThemeFoucScript()</code> in <code>&lt;head&gt;</code> so
+        <code>data-theme</code> is set before stylesheets load. This page
+        does it — check this file's <code>Layout.astro</code> for the
+        reference implementation.
+      </p>
+      <pre><code>{`---
+import { getThemeFoucScript } from '@fpkit/acss';
+const foucScript = getThemeFoucScript();
+---
+<html lang="en">
+  <head>
+    <script is:inline set:html={foucScript} />
+  </head>
+</html>`}</code></pre>
+      <p class="callout">
+        <strong>Custom storage key?</strong> Pass it to both
+        <code>ThemeProvider.storageKey</code> and
+        <code>getThemeFoucScript(key)</code>. Mismatched keys bring the flash
+        back.
+      </p>
+    </section>
+
+    <section aria-labelledby="custom-picker">
+      <h2 id="custom-picker">Building a custom picker</h2>
+      <p>
+        <code>ThemeToggle</code> is a three-state cycler (light → dark →
+        system). For a three-button radio group or a dropdown, compose with
+        <code>useTheme()</code>:
+      </p>
+      <pre><code>{`import { useTheme } from '@fpkit/acss';
+
+function ThemePicker() {
+  const { preference, setPreference } = useTheme();
+  return (
+    <fieldset>
+      <legend>Theme</legend>
+      <label><input type="radio" checked={preference === 'light'}
+        onChange={() => setPreference('light')} /> Light</label>
+      <label><input type="radio" checked={preference === 'dark'}
+        onChange={() => setPreference('dark')} /> Dark</label>
+      <label><input type="radio" checked={preference === 'system'}
+        onChange={() => setPreference('system')} /> Match system</label>
+    </fieldset>
+  );
+}`}</code></pre>
+    </section>
+
+    <aside class="see-also" aria-labelledby="see-also">
+      <h2 id="see-also">See also</h2>
+      <ul>
+        <li>
+          <a href={GITHUB_SOURCE}
+            >Full theming guide on GitHub</a
+          > — custom themes, API reference, verification procedures, troubleshooting.
+        </li>
+        <li><a href="/guides/tokens">Design tokens guide</a></li>
+        <li><a href="/foundations/colors">Foundations — colors in light + dark</a></li>
+        <li>
+          <a
+            href="https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/MIGRATION-v7.md#themeprovider-usetheme-themetoggle--additive"
+            >ThemeProvider migration steps</a
+          >
+        </li>
+      </ul>
+    </aside>
+  </article>
+
+  <style>
+    .page-intro {
+      margin-block-end: 2rem;
+    }
+    .breadcrumb {
+      margin: 0 0 0.5rem;
+      font-size: 0.875rem;
+      color: var(--color-text-tertiary);
+    }
+    .breadcrumb a {
+      color: var(--color-link);
+    }
+    .breadcrumb span[aria-current] {
+      color: var(--color-text);
+      font-weight: 600;
+    }
+    .page-intro p {
+      color: var(--color-text-secondary);
+      max-width: 48rem;
+    }
+    section {
+      margin-block-end: 2rem;
+    }
+    pre {
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      line-height: 1.5;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+      font-size: 0.9em;
+    }
+    .callout {
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-left: 3px solid var(--color-info, var(--color-primary));
+      padding: 0.75rem 1rem;
+      border-radius: 0.25rem;
+    }
+    .see-also {
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+    }
+    .see-also h2 {
+      margin-block: 0 0.5rem;
+      font-size: 1rem;
+    }
+    .see-also a {
+      color: var(--color-link);
+    }
+  </style>
+</Layout>

--- a/apps/astro-builds/src/pages/guides/tokens.astro
+++ b/apps/astro-builds/src/pages/guides/tokens.astro
@@ -1,0 +1,245 @@
+---
+/**
+ * Design tokens guide — condensed landing on the docs site.
+ *
+ * Full markdown (source of truth): packages/fpkit/docs/guides/design-tokens.md
+ * This page surfaces import paths, JSON vs TS module distinction, and a few
+ * representative token counts read live from @fpkit/acss/tokens.
+ */
+import Layout from "../../layouts/Layout.astro";
+import tokens from "@fpkit/acss/tokens";
+
+const GITHUB_SOURCE =
+  "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/design-tokens.md";
+
+// Live counts — read from the artifact the page is documenting.
+// Primitives nest as color.{palette}.{shade}; semantics sit at color.{name}.
+const colorTokens = tokens.color as Record<string, unknown>;
+const semanticColorCount = Object.entries(colorTokens).filter(
+  ([, v]) => typeof v === "object" && v !== null && "$value" in v
+).length;
+const primitiveColorCount = Object.entries(colorTokens).filter(
+  ([, v]) => typeof v === "object" && v !== null && !("$value" in v)
+).length;
+const durationCount = Object.keys(tokens.duration ?? {}).length;
+const easeCount = Object.keys(tokens.ease ?? {}).length;
+const breakpointCount = Object.keys(tokens.breakpoint ?? {}).length;
+---
+
+<Layout
+  title="Design tokens — @fpkit/acss guides"
+  description="The @fpkit/acss/tokens artifact — DTCG JSON plus a typed TS module, with consumption patterns for Figma, Astro, and native."
+>
+  <article>
+    <header class="page-intro">
+      <p class="breadcrumb" aria-label="Breadcrumb">
+        <a href="/guides/">Guides</a>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Design tokens</span>
+      </p>
+      <h1>Design tokens</h1>
+      <p>
+        <code>@fpkit/acss/tokens</code> ships two artifacts from the same build
+        step: a DTCG JSON file for cross-platform consumers (Figma, native,
+        docs sites) and a typed TypeScript module of <code>var()</code>
+        references for React runtime.
+      </p>
+    </header>
+
+    <section aria-labelledby="whats-in">
+      <h2 id="whats-in">What's in the artifact</h2>
+      <p>
+        Live counts from the build of <code>@fpkit/acss/tokens</code> that
+        generated this page:
+      </p>
+      <dl class="stat-grid">
+        <div class="stat">
+          <dt>Primitive color palettes</dt>
+          <dd>{primitiveColorCount}</dd>
+        </div>
+        <div class="stat">
+          <dt>Semantic color tokens</dt>
+          <dd>{semanticColorCount}</dd>
+        </div>
+        <div class="stat">
+          <dt>Motion durations</dt>
+          <dd>{durationCount}</dd>
+        </div>
+        <div class="stat">
+          <dt>Motion easings</dt>
+          <dd>{easeCount}</dd>
+        </div>
+        <div class="stat">
+          <dt>Breakpoints</dt>
+          <dd>{breakpointCount}</dd>
+        </div>
+      </dl>
+      <p class="note">
+        Typography and spacing tokens are on the roadmap — today they live
+        in component-scoped SCSS. Track progress in the <a href={GITHUB_SOURCE}
+          >design-tokens guide</a
+        >.
+      </p>
+    </section>
+
+    <section aria-labelledby="two-artifacts">
+      <h2 id="two-artifacts">Two artifacts, two jobs</h2>
+
+      <h3>JSON — cross-platform consumers</h3>
+      <pre><code>{`import tokens from '@fpkit/acss/tokens';
+
+tokens.color.primary.$value;
+// "#2563eb"
+
+tokens.color.primary.$extensions['com.fpkit.themeModes'].dark;
+// "#3b82f6"`}</code></pre>
+      <p>
+        Every semantic token carries its dark-mode override under
+        <code>$extensions['com.fpkit.themeModes'].dark</code>. Primitive
+        palettes don't — only semantic mappings flip.
+      </p>
+
+      <h3>TypeScript module — React runtime</h3>
+      <pre><code>{`import { tokens } from '@fpkit/acss/tokens';
+
+const styles = {
+  color: tokens.color.primary,     // "var(--color-primary)"
+  transition: \`color \${tokens.duration.base} \${tokens.ease.standard}\`,
+};`}</code></pre>
+      <p>
+        Each entry resolves to a <code>var()</code> reference — the resolved
+        color follows whatever <code>data-theme</code> is active on
+        <code>&lt;html&gt;</code>. No rebuild when the user toggles.
+      </p>
+    </section>
+
+    <section aria-labelledby="consumption">
+      <h2 id="consumption">Consumption patterns</h2>
+
+      <h3>Figma / native platforms</h3>
+      <p>
+        Point your Figma plugin at
+        <code>node_modules/@fpkit/acss/libs/tokens.json</code>. The DTCG
+        <code>$type</code> fields map one-to-one with Figma variable types
+        (<code>color</code>, <code>number</code>, <code>string</code>).
+      </p>
+
+      <h3>Astro docs site</h3>
+      <p>
+        The Foundations pages on this site render every token category live
+        from the JSON — open <a href="/foundations/colors">/foundations/colors</a>
+        to see the pattern in action. The source:
+        <code>apps/astro-builds/src/pages/foundations/colors.astro</code>.
+      </p>
+
+      <h3>Custom CSS generator</h3>
+      <pre><code>{`// Generate --mybrand-* aliases in your own build
+import tokens from '@fpkit/acss/tokens';
+// ...feed through style-dictionary or your preferred generator`}</code></pre>
+    </section>
+
+    <aside class="see-also" aria-labelledby="see-also">
+      <h2 id="see-also">See also</h2>
+      <ul>
+        <li>
+          <a href={GITHUB_SOURCE}
+            >Full design-tokens guide on GitHub</a
+          > — complete token shape, build pipeline, dark-mode extensions, Figma bridge notes.
+        </li>
+        <li><a href="/foundations/colors">Foundations — colors</a></li>
+        <li><a href="/foundations/motion">Foundations — motion</a></li>
+        <li><a href="/foundations/spacing">Foundations — spacing</a></li>
+        <li>
+          <a
+            href="https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/css-variables.md"
+            >CSS variable naming standard</a
+          >
+        </li>
+      </ul>
+    </aside>
+  </article>
+
+  <style>
+    .page-intro {
+      margin-block-end: 2rem;
+    }
+    .breadcrumb {
+      margin: 0 0 0.5rem;
+      font-size: 0.875rem;
+      color: var(--color-text-tertiary);
+    }
+    .breadcrumb a {
+      color: var(--color-link);
+    }
+    .breadcrumb span[aria-current] {
+      color: var(--color-text);
+      font-weight: 600;
+    }
+    .page-intro p {
+      color: var(--color-text-secondary);
+      max-width: 48rem;
+    }
+    section {
+      margin-block-end: 2rem;
+    }
+    h3 {
+      margin-block: 1.5rem 0.5rem;
+    }
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+      gap: 0.75rem;
+      margin: 0;
+      padding: 0;
+    }
+    .stat {
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+    }
+    .stat dt {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--color-text-secondary);
+      margin: 0;
+    }
+    .stat dd {
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+    pre {
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      line-height: 1.5;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+      font-size: 0.9em;
+    }
+    .note {
+      color: var(--color-text-secondary);
+      font-size: 0.9375rem;
+    }
+    .see-also {
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-elevated);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 0.5rem;
+    }
+    .see-also h2 {
+      margin-block: 0 0.5rem;
+      font-size: 1rem;
+    }
+    .see-also a {
+      color: var(--color-link);
+    }
+  </style>
+</Layout>

--- a/apps/astro-builds/src/pages/guides/tokens.astro
+++ b/apps/astro-builds/src/pages/guides/tokens.astro
@@ -98,18 +98,15 @@ tokens.color.primary.$extensions['com.fpkit.themeModes'].dark;
         <code>$extensions['com.fpkit.themeModes'].dark</code>. Primitive
         palettes don't — only semantic mappings flip.
       </p>
-
-      <h3>TypeScript module — React runtime</h3>
-      <pre><code>{`import { tokens } from '@fpkit/acss/tokens';
-
-const styles = {
-  color: tokens.color.primary,     // "var(--color-primary)"
-  transition: \`color \${tokens.duration.base} \${tokens.ease.standard}\`,
-};`}</code></pre>
       <p>
-        Each entry resolves to a <code>var()</code> reference — the resolved
-        color follows whatever <code>data-theme</code> is active on
-        <code>&lt;html&gt;</code>. No rebuild when the user toggles.
+        The package also generates a typed TypeScript module at
+        <code>src/tokens/index.ts</code> whose entries resolve to{" "}
+        <code>var()</code> references for runtime theme-aware styling. It
+        isn't exposed via a package subpath yet — see the{" "}
+        <a
+          href="https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/docs/guides/design-tokens.md"
+          >full design-tokens guide</a
+        > for the roadmap.
       </p>
     </section>
 

--- a/docs/planning/let-s-document-the-changes-prancy-minsky.md
+++ b/docs/planning/let-s-document-the-changes-prancy-minsky.md
@@ -1,0 +1,326 @@
+# Plan: Document the design-system conversion (Phases 1–7A)
+
+## Context
+
+Between Phases 1 and 7A (commits `3a290db` → `2f51db1`, landing across v6.x minors), `@fpkit/acss` converted from a component library into a design system:
+
+- **Phase 1** — governance + theme-ready semantic tokens (no hardcoded hex)
+- **Phase 2** — DTCG token pipeline (`@fpkit/acss/tokens` JSON + TS module)
+- **Phase 3** — theming runtime (`ThemeProvider`, `useTheme`, `ThemeToggle`, FOUC script)
+- **Phase 4** — component completion (Link `disabled`, Button `color="info"`) + v7 migration scaffold
+- **Phase 5** — CI quality gates (vitest coverage, size-limit, axe, Chromatic, Changesets)
+- **Phase 6** — public Astro docs site (`apps/astro-builds/`) with Foundations pages driven from tokens
+- **Phase 7A** — component maturity dashboard at `/status`
+
+Most of the **reference material already exists** — `packages/fpkit/docs/guides/` has 11 files and `MIGRATION-v7.md` documents every breaking/additive change. What's missing is:
+
+1. A **single narrative** that tells the "v6 design-system story" — readers hitting the repo today see the recap in `README.md` (one paragraph) or ~30 scattered commits, but no single doc.
+2. **Operations docs** for contributors — CI gates rationale, bundle-size budgets, maturity-dashboard signal semantics. Info exists in `MIGRATION-v7.md` but buried under "Release & CI."
+3. **Code examples in `MIGRATION-v7.md`** — the doc describes *what* changed but rarely shows before/after React/SCSS diffs.
+4. **Astro site coverage** — the public docs site ships Foundations + Status but not Guides. Consumers have to dig into the GitHub repo's markdown files to read theming, tokens, migration content.
+
+Goal: close those four gaps without duplicating the existing guide content, and split work by audience.
+
+---
+
+## Scope
+
+The user confirmed all four doc shapes are in scope, split per-doc by audience:
+
+| Workstream | Audience | Deliverable |
+|---|---|---|
+| **A.** Public recap doc | Consumers | New `packages/fpkit/docs/DESIGN-SYSTEM-v6.md` — Phase-by-phase narrative |
+| **B.** Fill guide gaps | Contributors | New `ci-gates.md` + new `maturity-dashboard.md` + Troubleshooting section in `theming.md` |
+| **C.** Expand `MIGRATION-v7.md` | Consumers | Add "Upgrade steps" with before/after code per section |
+| **D.** New Astro site pages | Consumers | `/guides/` section on `apps/astro-builds/` surfacing tokens, theming, migration |
+| **E.** Discoverability | Both | Docs-directory index + Astro search + sitemap + canonical links + badges + cross-reference matrix |
+| **F.** Accessibility | Both | WCAG 2.1 AA compliance for all new/modified docs + Astro pages audit + docs a11y checklist in `CONTRIBUTING.md` |
+
+---
+
+## Recommended approach
+
+### Workstream A — Public recap doc (consumer-facing)
+
+**Create:** `packages/fpkit/docs/DESIGN-SYSTEM-v6.md`
+
+**Shape:** narrative, scannable, ≤ 500 lines. Outline:
+
+1. **TL;DR** — one paragraph + the 7 phases as a bulleted timeline with versions (which v6.x minor shipped each).
+2. **What's new for consumers** — dark mode, token pipeline, new APIs (`ThemeProvider`, `useTheme`, `ThemeToggle`, `getThemeFoucScript`), `@fpkit/acss/tokens` subpath, Link `disabled`, Button `color="info"`. Each bullet links to the deep guide.
+3. **What's new for contributors** — CI gates, Changesets, maturity dashboard, plan-directory policy. Each bullet links to the deep guide.
+4. **Upgrade path** — cross-link to `MIGRATION-v7.md` with a short "minimum viable upgrade" checklist.
+5. **Where to learn more** — matrix of guide → what-it-covers, with direct links to `packages/fpkit/docs/guides/*.md` and the Astro site pages.
+
+**Rationale:** Serves as the landing doc for anyone skimming the repo after the v6.x series. Doesn't duplicate guide content — it's a map.
+
+---
+
+### Workstream B — Fill guide gaps (contributor-facing)
+
+**B.1. Create `packages/fpkit/docs/guides/ci-gates.md`**
+
+Sections:
+
+- **Coverage thresholds** — vitest config at `packages/fpkit/vitest.config.js` (Lines 89%, Branches 90%, Functions 66%, Statements 89%). Why the ~2pp headroom below baseline. Roadmap target (95%+ lines, 85%+ functions). How to run `npm run test:coverage` locally and interpret the HTML report.
+- **Bundle-size budgets** — `packages/fpkit/.size-limit.cjs` (main 18 KB, hooks 3 KB, icons 6 KB, CSS 18 KB gzipped). Baselines. Why CSS budget is tight (~3% headroom). Running `npm run size` and `npm run size:why`. When/how to recalibrate.
+- **Accessibility gate** — `.github/workflows/a11y.yml` runs Storybook test-runner + axe. Currently non-blocking (`continue-on-error: true`). How to opt a story out (`parameters: { a11y: { disable: true } }`). Path to flip back to blocking.
+- **Visual regression (Chromatic)** — `.github/workflows/chromatic.yml` is gated on `CHROMATIC_PROJECT_TOKEN` secret. How to bring the first baseline online; when to remove `continue-on-error`.
+- **Release flow (Changesets)** — replaces Lerna version/publish. How to author a changeset, the Version Packages PR flow, action required for maintainers.
+- **Local pre-PR checklist** — run lint, test, coverage, size, build-storybook before pushing.
+
+Reuse existing paths: `.github/workflows/{test,a11y,chromatic,release,deploy-docs}.yml`, `.changeset/README.md`, `packages/fpkit/vitest.config.js`, `packages/fpkit/.size-limit.cjs`.
+
+**B.2. Create `packages/fpkit/docs/guides/maturity-dashboard.md`**
+
+Sections:
+
+- **What `/status` is** — build-time static page at `apps/astro-builds/src/pages/status.astro`. No client JS. Source of truth: `apps/astro-builds/src/lib/component-status.ts`.
+- **Lifecycle vocabulary** — `experimental` / `beta` / `rc` / `stable` / `deprecated`. Cross-link `component-lifecycle.md`. The `alpha → experimental` rename happened in Phase 7A.
+- **How signals are computed** — where each column comes from (story tags, presence of `.test.tsx`, a11y tag on story metadata, dark-mode verification marker).
+- **How to tag a new component** — edit `meta.tags` in `{component}.stories.tsx`; rebuild the Astro site to see it in the dashboard.
+- **When to promote a component** — criteria for each lifecycle stage (short; defer to `component-lifecycle.md` for depth).
+
+**B.3. Add a "Verification & troubleshooting" section to `packages/fpkit/docs/guides/theming.md`**
+
+Append after the existing "Accessibility notes" section:
+
+- **Verifying dark mode in Storybook** — until the Storybook theme toolbar ships, how to manually toggle (`document.documentElement.setAttribute('data-theme', 'dark')` in the DevTools console).
+- **Chromatic baselines for dark mode** — how to capture paired light/dark snapshots once the token is live; baseline reset procedure.
+- **Common issues** — FOUC still flashes (mismatched `storageKey`), `useTheme` throws (missing provider), custom theme name not detected by `ThemeToggle` (expected — cycler only handles built-ins).
+
+---
+
+### Workstream C — Expand `MIGRATION-v7.md` (consumer-facing)
+
+Current file: `packages/fpkit/MIGRATION-v7.md` (173 lines) — already well-organized; lacks code examples in 6 of its ~12 subsections.
+
+Add a ## Upgrade steps subsection *inside* each of these existing sections with before/after snippets:
+
+1. **CSS overlay tokens** — before: `background: rgba(0, 0, 0, 0.08)` hard-coded. After: `background: var(--color-hover-overlay)`.
+2. **ThemeProvider wire-up** — before: app root without provider. After: wrapped in `ThemeProvider`, `ThemeToggle` in header, `getThemeFoucScript()` inlined in document head (with Astro + Next.js examples side-by-side).
+3. **Token imports** — before: duplicating hex values in app CSS. After: `import tokens from '@fpkit/acss/tokens'` usage snippet.
+4. **Button `color="info"`** — before: custom CSS to add info-colored button. After: `<Button color="info">`.
+5. **Link `disabled`** — before: app-level state + conditional render. After: `<Link disabled={!canEdit}>`.
+6. **Heading → Title** — before/after JSX snippet (already present; tighten it and add a codemod regex in a sidebar note: `rg 'Heading type=' → Title level=`).
+
+Also add a **"Minimum viable v6→v6.latest upgrade"** checklist at the top (before the existing "Tracking status" legend): 5 bullets of the absolute-minimum steps a consumer needs to pick up theming + tokens.
+
+---
+
+### Workstream D — New Astro docs site `/guides/` pages (consumer-facing)
+
+**Create:**
+
+- `apps/astro-builds/src/pages/guides/index.astro` — landing page; grid of guide cards (Tokens, Theming, Migration, CSS Variables).
+- `apps/astro-builds/src/pages/guides/theming.astro` — rendered version. Content comes from `packages/fpkit/docs/guides/theming.md`. Use Astro Content Collections if one already exists, otherwise import the md content at build time with `astro:content` or a simple Markdown island. Verify which approach Phase 6 established.
+- `apps/astro-builds/src/pages/guides/tokens.astro` — same treatment for `design-tokens.md`.
+- `apps/astro-builds/src/pages/guides/migration.astro` — consumer-focused slice of `MIGRATION-v7.md` (skip "Release & CI" section for this surface).
+
+**Modify:**
+
+- `apps/astro-builds/src/components/SiteHeader.tsx` — add "Guides" nav item between existing "Foundations" and "Status" links. Check current nav implementation before editing.
+
+**Decision point:** before implementing, verify whether `apps/astro-builds/` has already adopted Astro Content Collections (a `src/content/` directory with a `config.ts`). If yes, add each guide as a collection entry. If no, inline-render with a simple frontmatter import. The `Plan` agent should flag which approach the existing Foundations pages use so guides follow the same pattern.
+
+---
+
+## Critical files
+
+**To create:**
+
+- `packages/fpkit/docs/DESIGN-SYSTEM-v6.md` (Workstream A)
+- `packages/fpkit/docs/guides/ci-gates.md` (Workstream B.1)
+- `packages/fpkit/docs/guides/maturity-dashboard.md` (Workstream B.2)
+- `packages/fpkit/docs/README.md` (Workstream E — docs directory index)
+- `apps/astro-builds/src/pages/guides/index.astro` (Workstream D)
+- `apps/astro-builds/src/pages/guides/theming.astro` (Workstream D)
+- `apps/astro-builds/src/pages/guides/tokens.astro` (Workstream D)
+- `apps/astro-builds/src/pages/guides/migration.astro` (Workstream D)
+
+**To modify:**
+
+- `packages/fpkit/docs/guides/theming.md` — append troubleshooting section (Workstream B.3)
+- `packages/fpkit/MIGRATION-v7.md` — add per-section upgrade-step blocks + minimum-viable-upgrade checklist (Workstream C)
+- `apps/astro-builds/src/components/SiteHeader.tsx` — add Guides nav link + search affordance (Workstream D, E)
+- `apps/astro-builds/src/layouts/Layout.astro` — add skip link + canonical link tag (Workstream F, E)
+- `apps/astro-builds/astro.config.mjs` — register `@astrojs/sitemap` integration (Workstream E)
+- `README.md` (root) — add "Design system" section + badges (Workstream A, E)
+- `packages/fpkit/README.md` — add link to `DESIGN-SYSTEM-v6.md` (Workstream A, E)
+- `CONTRIBUTING.md` — add "Docs accessibility checklist" subsection (Workstream F)
+- `.vscode/css-custom-data.json` — add descriptions for new token categories (Workstream E; create if missing)
+
+**To read but not modify (sources of truth to cite):**
+
+- `.github/workflows/{test,a11y,chromatic,release,deploy-docs}.yml` — for the CI gates guide
+- `packages/fpkit/vitest.config.js` and `packages/fpkit/.size-limit.cjs` — threshold numbers
+- `apps/astro-builds/src/lib/component-status.ts` — dashboard signal logic
+- `apps/astro-builds/src/pages/status.astro` — dashboard rendering
+- `apps/astro-builds/src/pages/foundations/*.astro` — Astro page conventions to mirror for guides
+- `.changeset/config.json` and `.changeset/README.md` — release-flow specifics
+- `apps/astro-builds/src/components/SiteHeader.tsx` — existing nav shape
+
+---
+
+## Existing utilities & patterns to reuse
+
+- `@fpkit/acss/tokens` JSON import pattern — already used by `apps/astro-builds/src/pages/foundations/*.astro`. Guide pages should follow the same import path.
+- `SiteHeader.tsx` (React island) — already hydrates with ThemeToggle. New nav links slot into existing markup; no pattern change needed.
+- `ensure-fpkit-build` prescript in `apps/astro-builds/package.json` — already guards against missing `libs/tokens.json` before dev/build. No changes needed.
+- Existing doc tone/formatting in `packages/fpkit/docs/guides/` — mimic `design-tokens.md` structure (table of contents, tables for props/fields, "See also" footer).
+- `MIGRATION-v7.md` status legend (`✅ / ⚠️ / 💥`) — keep; applies to new upgrade-step blocks too.
+
+---
+
+## Verification
+
+**Workstream A, B, C (markdown):**
+
+1. Run a markdown link-checker (e.g. `npx markdown-link-check packages/fpkit/docs/**/*.md`) to catch broken cross-links.
+2. Manually read each new/modified doc top-to-bottom in the GitHub web UI preview — flags rendering issues (tables, code fences, relative links).
+3. Confirm the DESIGN-SYSTEM-v6.md outline covers every Phase 1–7A deliverable from git log.
+
+**Workstream D (Astro pages):**
+
+1. `cd apps/astro-builds && npm run dev` — verify `/guides/`, `/guides/theming`, `/guides/tokens`, `/guides/migration` routes render.
+2. Click every internal link; confirm theme toggle still works (dark mode applies to guide pages).
+3. `npm run build` — confirm static build succeeds; check `dist/guides/*.html` exist.
+4. Run `.github/workflows/deploy-docs.yml` locally (act) or via PR preview — confirm CI still deploys.
+
+**Contributor CI-gates guide verification:**
+
+1. Run `cd packages/fpkit && npm run test:coverage` — numbers in the doc should match the actual current output.
+2. Run `npm run size` — sizes in the doc should match actual.
+3. If numbers drift, the doc's accuracy is load-bearing — treat mismatches as a doc bug.
+
+**No code behavior changes** — this is documentation-only work. No test suite changes or vitest runs needed for library correctness.
+
+**Workstream E (Discoverability):**
+
+1. `markdown-link-check` across all new/modified `.md` files — catches broken cross-refs between DESIGN-SYSTEM-v6.md, guides, and MIGRATION.
+2. `cd apps/astro-builds && npm run build` — confirm `dist/sitemap-index.xml` and `dist/sitemap-0.xml` generate; confirm `pagefind` index builds (if adopted) at `dist/pagefind/`.
+3. Open the built site, use the search input, verify a query for "theme" returns the theming guide. Verify "coverage" returns the ci-gates guide.
+4. Walk from `README.md` → `DESIGN-SYSTEM-v6.md` → a random guide → the Astro page for that guide → back to GitHub source. Every transition should be one click.
+5. Confirm every guide page has a "See also" footer with ≥ 2 lateral links.
+
+**Workstream F (Accessibility):**
+
+1. Run `markdownlint` on all new/modified `.md` files with rules `MD001` (heading hierarchy), `MD042` (no empty links), `MD045` (images alt text). Add the config to `.markdownlint.json` if missing.
+2. Install `axe DevTools` browser extension; run against every `/guides/*` page and every `/foundations/*` page in **both light and dark themes**. Zero critical or serious violations.
+3. Keyboard-only pass: unplug/disable mouse; tab through every page. Every interactive element reachable; visible focus ring on every focus; skip link works on first tab; no keyboard traps.
+4. Screen-reader pass (one platform sufficient — VoiceOver on macOS or NVDA on Windows): verify heading hierarchy is announced correctly; Status table announces column headers; color swatches announce their token name.
+5. `prefers-reduced-motion` pass: enable OS-level reduced motion; confirm no transitions on any guide page.
+6. Color-contrast check: use axe or WebAIM contrast checker for swatch label text in `colors.astro` under both themes — 4.5:1 for body text.
+7. File any issues that surface as follow-up tickets; document in DESIGN-SYSTEM-v6.md under "Known a11y follow-ups." Blocks release only if critical violations surface.
+
+---
+
+## Discoverability
+
+The existing content is strong; the *paths to reach it* are weak. Three reader entry points need linking into one map:
+
+**Entry point 1 — npm / GitHub README (first-time arrival)**
+
+- `README.md` (root) and `packages/fpkit/README.md`: add a **"Design system"** heading near the top with three bullets linking to:
+  1. `packages/fpkit/docs/DESIGN-SYSTEM-v6.md` (the recap)
+  2. The Astro docs site URL (once `deploy-docs.yml` has run; until then, link to `apps/astro-builds/`)
+  3. `packages/fpkit/MIGRATION-v7.md`
+- Add three shield badges at the top of the root README (under the existing package badge): *docs site*, *coverage*, *bundle size* — standard shields.io format pointing at the deploy-docs URL, Codecov (if wired; skip otherwise), and size-limit badge.
+
+**Entry point 2 — `packages/fpkit/docs/` (docs directory)**
+
+- Create `packages/fpkit/docs/README.md` (or `INDEX.md`) — a one-screen directory listing every guide with a one-line purpose statement. Today a reader in the `docs/` folder sees 11 files with no overview.
+- Group the listing: **Getting started** (design-principles, architecture), **Tokens & theming** (design-tokens, theming, css-variables), **Contributing** (component-lifecycle, variants, testing, storybook, ci-gates, maturity-dashboard), **Accessibility** (accessibility, composition).
+
+**Entry point 3 — Astro docs site (`apps/astro-builds/`)**
+
+- Add a global **search affordance** to `SiteHeader.tsx` — use Astro's built-in Pagefind integration (`npx pagefind` at build time) or a minimal search input that filters by page title. Pagefind is the lowest-friction option: zero-runtime, client-indexed, works with static builds. Document choice in the plan file during implementation.
+- Add a **sitemap**: enable `@astrojs/sitemap` integration in `apps/astro-builds/astro.config.mjs` — one line to register, auto-generates `/sitemap.xml` from all pages. Helps search engines index the guides.
+- Add **`<link rel="canonical">`** to each page's `Layout.astro` so duplicate content (markdown in repo + rendered page in site) doesn't split search authority.
+- Every new guide page ends with a consistent **"See also"** footer mirroring the markdown guides' footer convention — lateral links between related guides.
+
+**Cross-reference matrix (bidirectional links):**
+
+- `DESIGN-SYSTEM-v6.md` links out to every guide. Every guide's "See also" footer links back to `DESIGN-SYSTEM-v6.md` as "The v6 design system overview."
+- `MIGRATION-v7.md` links to each relevant guide section (tokens → `design-tokens.md#consumption-patterns`, theming → `theming.md#quick-start`).
+- Astro `/guides/theming` page links to GitHub source (`packages/fpkit/docs/guides/theming.md`) for readers who prefer raw markdown or want to suggest edits via PR.
+
+**IDE discoverability:**
+
+- Extend the existing VS Code `.vscode/css-custom-data.json` hint (referenced in `docs/css-variables.md`) to cover new token categories — `--duration-*`, `--ease-*`, `--breakpoint-*`, `--color-ui-overlay-base`. Adds autocomplete descriptions as developers type.
+
+---
+
+## Accessibility
+
+The library's own accessibility bar is WCAG 2.1 AA (see `packages/fpkit/docs/guides/accessibility.md`). The docs themselves must meet the same bar — both the markdown (rendered on GitHub and in the Astro site) and the Astro pages' custom components.
+
+**Markdown-level accessibility (applies to all new/modified `.md` files):**
+
+- **Heading hierarchy** — no skipped levels (`##` → `####` is a fail). Each page has exactly one `#` (the title). Validate with `markdownlint` rule `MD001`.
+- **Alt text on every image** — including decorative images (`alt=""`). No image-only content.
+- **Link text is descriptive** — no "click here" or "read more"; use "See the theming guide" style. Screen-reader users navigate by link list.
+- **Code blocks specify a language** — `~~~tsx`, `~~~scss`, `~~~bash`. Enables proper syntax highlighting which helps cognitive accessibility (color-coded tokens reduce parse load).
+- **Tables have header rows** — use markdown `|---|---|` syntax consistently. Screen readers announce column context.
+- **Color isn't the only signal** — the `✅ / ⚠️ / 💥` legend in `MIGRATION-v7.md` already includes text labels; keep this convention.
+
+**Astro docs site accessibility (new `/guides/*` pages):**
+
+Each new page must:
+
+1. **Use semantic HTML** — `<main>`, `<nav>`, `<article>`, `<aside>`. The fpkit `Layout` components (Main, Aside, Footer) already enforce this — reuse them.
+2. **One `<h1>` per page** — followed by a logical heading outline. Validate by opening the page in DevTools, inspecting the accessibility tree.
+3. **Skip link** — add a "Skip to main content" link as the first focusable element in `Layout.astro`. Visually hidden until focused. Mandatory under WCAG 2.4.1.
+4. **Focus indicators** — the ThemeToggle already inherits focus styles from `Button`; verify new nav links in `SiteHeader.tsx` render the same focus ring. Never suppress `:focus-visible`.
+5. **Color contrast in both themes** — every text/background combination in the guide pages must meet WCAG 2.1 AA (4.5:1 for body, 3:1 for 18px+/bold). Run the `a11y.yml` test-runner on the Storybook build; then manually audit the Astro pages with axe DevTools extension. The Foundations pages render swatches from `@fpkit/acss/tokens` — verify the label text over each swatch hits 4.5:1. If not, swap to text-on-neutral-surface with a colored border.
+6. **Keyboard navigation** — tab through every new page; every interactive element reachable, tab order matches visual order, no keyboard traps. Especially validate the ThemeToggle + search input interaction.
+7. **`prefers-reduced-motion`** — if any guide page adds transitions (card hover lift, accordion expand), wrap them in `@media (prefers-reduced-motion: no-preference)`.
+8. **`prefers-color-scheme`** — the existing `ThemeProvider` handles this; confirm new pages don't break the contract by hardcoding colors.
+
+**Foundations pages (`colors.astro`, etc.) — existing surface, audit now:**
+
+Take this doc pass as the opportunity to audit the Phase 6 Foundations pages that already exist:
+
+- `colors.astro` — each swatch should expose **both the visual color and the token name as text**; color-blind users can't identify swatches by hue alone. Verify aria labels and text labels are paired.
+- `typography.astro` — sample text in each type scale entry should be **real prose**, not "Lorem ipsum" — real words help screen-reader users verify the scale.
+- `spacing.astro` / `motion.astro` — visual demos (spacing bars, motion loops) must have text captions stating the rem value or duration token name; motion should respect `prefers-reduced-motion`.
+
+If the audit turns up issues, file them as follow-ups rather than blocking this doc PR. Document the findings in a short appendix at the end of `DESIGN-SYSTEM-v6.md` under "Known a11y follow-ups for the docs site."
+
+**Status dashboard (`/status`) — data-table accessibility:**
+
+The `status.astro` page renders a component matrix. Verify (or add to the maturity-dashboard guide):
+
+- Uses `<table>` with `<thead>` / `<tbody>` / `<th scope="col">` — not a `<div>` grid.
+- Lifecycle-stage cells expose both a color *and* a text label (`"stable"`, `"experimental"`) — don't encode stage by color alone.
+- The table has a `<caption>` or an `aria-labelledby` pointing at the page heading.
+
+**Verification hooks:**
+
+- Add a line to the **CI-gates guide** (Workstream B.1) documenting that the existing `a11y.yml` axe gate covers component stories but **not** the Astro docs site. Recommend running `axe-core` or `@axe-core/cli` against the built docs site as a follow-up gate — not in scope for this PR but worth flagging.
+- Add a **Docs accessibility checklist** to `CONTRIBUTING.md` (one new subsection under the existing quality bars) — 8-item checklist that every docs PR author runs locally before opening a PR. Keeps the bar enforced beyond this one-off effort.
+
+---
+
+## Out of scope
+
+- Typography/spacing token pipeline (acknowledged as "not yet in the token pipeline" in `design-tokens.md`; tracked in `MIGRATION-v7.md`).
+- Storybook theme toolbar (deferred from Phase 3; guide will note manual toggle as the workaround).
+- Chromatic baseline capture (requires `CHROMATIC_PROJECT_TOKEN` secret; guide will document the procedure but not execute it).
+- Rewriting existing guides — `design-tokens.md`, `theming.md` (other than adding the troubleshooting section), `component-lifecycle.md`, etc. are kept as-is.
+- Astro Content Collections migration for *existing* foundations pages — only new guide pages adopt whichever convention is already in use.
+
+---
+
+## Sequencing
+
+Recommended order (each step independently reviewable):
+
+1. **Workstream C** (expand `MIGRATION-v7.md`) — smallest, highest consumer value; establishes the before/after code snippets that later workstreams link to.
+2. **Workstream A** (DESIGN-SYSTEM-v6.md) — can be written once C is done, since it links heavily to MIGRATION.
+3. **Workstream B** (ci-gates + maturity-dashboard + theming troubleshooting) — parallelizable; each doc is self-contained.
+4. **Workstream E** (discoverability) — fold in as each earlier workstream lands: cross-links added during A/B/C writing, docs `README.md` written after B finishes, Astro search/sitemap added during D.
+5. **Workstream D** (Astro `/guides/` pages) — requires A/B/C content to exist so the Astro pages can import or mirror it.
+6. **Workstream F** (accessibility) — runs *continuously* through each step, not as a final pass: every new doc lint-checks as it's written; every Astro page axe-checks before merge. A final audit pass at the end catches cross-page issues.
+
+Estimated scope: 5 new markdown files, 3 new Astro pages, 8 modified files. No code logic changes.

--- a/packages/fpkit/MIGRATION-v7.md
+++ b/packages/fpkit/MIGRATION-v7.md
@@ -247,7 +247,7 @@ Links now accept `disabled?: boolean`. The component applies `aria-disabled`, su
 <Link href="/settings" disabled={!canEdit}>Edit settings</Link>
 ```
 
-Why keep the element in tab order? WCAG 2.1.1 (Keyboard): every piece of functionality must be keyboard-operable *and discoverable*. Removing the link from the DOM hides the fact that it existed — a screen-reader user has no way to know "this action is temporarily unavailable."
+Why keep the element in tab order? As an accessibility-focused library behavior, leaving the disabled link focusable helps keyboard and assistive-technology users perceive that the action exists, even when it is temporarily unavailable. Removing the link from the DOM can hide that option entirely, so a user may have no way to know the action is unavailable right now.
 
 ### Alert — `data-alert` + `data-variant` documented exception (no change)
 

--- a/packages/fpkit/MIGRATION-v7.md
+++ b/packages/fpkit/MIGRATION-v7.md
@@ -2,6 +2,20 @@
 
 This guide collects every breaking or semi-breaking change that accumulates across the design-system conversion roadmap (see `docs/planning/i-want-to-convert-nested-waffle.md`). A **v7.0.0** release will bundle them; some entries are additive and ship in v6.x minors.
 
+## Minimum viable v6.x upgrade
+
+You're on an older v6 minor and want to pick up theming + tokens today. The absolute-minimum steps:
+
+1. **Bump the package** — `npm install @fpkit/acss@latest`. All changes below are additive in v6.x; nothing breaks.
+2. **Wrap your app in `ThemeProvider`** and render a `ThemeToggle` (or call `useTheme()` from your own picker). See [`ThemeProvider` upgrade steps](#themeprovider-useTheme-themetoggle--additive) below.
+3. **SSR apps only**: inline `getThemeFoucScript()` in your document `<head>` before any styles load — prevents theme-flash on first paint. See [FOUC upgrade steps](#fouc-prevention-script--additive).
+4. **Drop hand-coded hover/active overlays** (`rgba(0, 0, 0, 0.08)` style) in favor of `var(--color-hover-overlay)` / `var(--color-active-overlay)` so your styles flip correctly under dark mode. See [overlay token upgrade steps](#css-custom-properties-for-ui-overlays--additive).
+5. **If you style links yourself** and you've added an `aria-disabled` or click-suppressed variant, replace it with the new `disabled` prop on `<Link>` — you get keyboard-reachable disabled state for free. See [Link upgrade steps](#link--disabled-prop-added--additive).
+
+That's enough to make dark mode work and bring your app onto the token surface. Everything below is depth.
+
+> **v7.0.0 forward-compatibility:** every item in this list is a v6.x minor. The only changes that will land in v7 are the ones marked 💥 below. If you're green on the list above, you're green for v7 too.
+
 **Tracking status:**
 
 - ✅ = shipped in a v6 minor (additive; no action required)
@@ -18,7 +32,33 @@ This guide collects every breaking or semi-breaking change that accumulates acro
 `_color-semantic.scss` introduces `--color-ui-overlay-base` as an RGB triplet (`0, 0, 0` light / `255, 255, 255` dark). Hover and active overlays (`--color-hover-overlay`, `--color-active-overlay`) are now composed via `rgba(var(--color-ui-overlay-base), …)` so they invert correctly under `[data-theme="dark"]`.
 
 **Migration**
-Nothing to do for consumers that only reference `--color-hover-overlay` / `--color-active-overlay`. If you hard-coded `rgba(0, 0, 0, X)` in your own overrides, switch to the composed form so your styles follow the active theme.
+Nothing to do for consumers that only reference `--color-hover-overlay` / `--color-active-overlay`. If you hard-coded overlay colors, switch to the composed form so your styles follow the active theme.
+
+**Upgrade steps**
+
+```scss
+/* Before — dark mode ignores this, overlay stays black */
+.card:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+/* After — inverts automatically when [data-theme="dark"] is set */
+.card:hover {
+  background: var(--color-hover-overlay);
+}
+
+/* Or compose your own overlay with a different alpha */
+.card:active {
+  background: rgba(var(--color-ui-overlay-base), 0.16);
+}
+```
+
+Find candidates to migrate with a quick ripgrep:
+
+```bash
+rg 'rgba\(0,\s*0,\s*0' src/
+rg 'rgba\(255,\s*255,\s*255' src/
+```
 
 ### New token categories (✅ additive)
 
@@ -31,6 +71,34 @@ These are exposed via `@fpkit/acss/tokens` (the generated JSON artifact) and `@f
 ### `libs/tokens.json` export (✅ additive)
 
 Consumers can now `import tokens from '@fpkit/acss/tokens'` to get every token with dark-mode extensions. Useful for docs sites, native apps, and Figma bridges.
+
+**Upgrade steps**
+
+```ts
+// Before — hex values duplicated in app CSS, no dark override
+const primary = '#2563eb';
+const primaryHover = '#1d4ed8';
+
+// After — one source of truth, dark value is discoverable
+import tokens from '@fpkit/acss/tokens';
+
+const primary = tokens.color.primary.$value;                                        // "#2563eb"
+const primaryDark = tokens.color.primary.$extensions?.['com.fpkit.themeModes']?.dark; // "#3b82f6"
+```
+
+For React runtime use — where the value should follow whatever `data-theme` is active — import the typed `var()` references instead:
+
+```tsx
+// TS module — each entry resolves to a `var(--...)` reference
+import { tokens } from '@fpkit/acss/tokens';
+
+const styles = {
+  color: tokens.color.primary,          // "var(--color-primary)"
+  transition: `color ${tokens.duration.base} ${tokens.ease.standard}`,
+};
+```
+
+See the [Design Tokens guide](docs/guides/design-tokens.md) for the full shape + Figma/native consumption patterns.
 
 ---
 
@@ -51,6 +119,36 @@ import { ThemeProvider, ThemeToggle, useTheme } from '@fpkit/acss';
 
 `ThemeProvider` writes `data-theme="light"` or `data-theme="dark"` on `document.documentElement`, watches `prefers-color-scheme` when preference is `"system"`, and persists to `localStorage`.
 
+**Upgrade steps**
+
+```tsx
+// Before — app root has no theme context; dark mode isn't wired
+function App() {
+  return (
+    <header>
+      <button>Toggle theme (no-op)</button>
+    </header>
+  );
+}
+
+// After — wrap once, drop ThemeToggle in the header, every token-driven
+// component picks up light/dark automatically
+import { ThemeProvider, ThemeToggle } from '@fpkit/acss';
+
+function App() {
+  return (
+    <ThemeProvider defaultPreference="system">
+      <header>
+        <ThemeToggle display="icon" />
+      </header>
+      <main>{/* … */}</main>
+    </ThemeProvider>
+  );
+}
+```
+
+For a custom picker (three explicit buttons instead of a cycler), use `useTheme()` directly — see the [Theming guide](docs/guides/theming.md#usetheme).
+
 ### FOUC prevention script (✅ additive)
 
 For SSR apps (Next.js, Astro, Remix):
@@ -63,6 +161,51 @@ import { getThemeFoucScript } from '@fpkit/acss';
 
 Inject before any styles load to avoid a theme flash on first paint.
 
+**Upgrade steps — framework-specific**
+
+```astro
+<!-- Astro — src/layouts/Layout.astro -->
+---
+import { getThemeFoucScript } from '@fpkit/acss';
+const foucScript = getThemeFoucScript();
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <script is:inline set:html={foucScript} />
+    {/* ...rest of head */}
+  </head>
+  <body><slot /></body>
+</html>
+```
+
+```tsx
+// Next.js (App Router) — app/layout.tsx
+import { getThemeFoucScript } from '@fpkit/acss';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: getThemeFoucScript() }} />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+`suppressHydrationWarning` on `<html>` is required for Next.js — the FOUC script sets `data-theme` before React hydrates, producing a legitimate attribute mismatch the flag silences.
+
+Using a custom storage key? Pass it to **both** the provider and the FOUC helper (mismatched keys re-introduce the flash):
+
+```tsx
+<ThemeProvider storageKey="my-app-theme">{children}</ThemeProvider>
+
+// And in document head:
+getThemeFoucScript('my-app-theme');
+```
+
 ---
 
 ## Components
@@ -71,7 +214,19 @@ Inject before any styles load to avoid a theme flash on first paint.
 
 Brings Button to parity with Alert's semantic colors. No breaking change; existing `primary`/`secondary`/`danger`/`success`/`warning` are unchanged.
 
+**Upgrade steps**
+
 ```tsx
+// Before — custom CSS to add an info-colored button
+<Button
+  type="button"
+  className="btn-info"
+  style={{ '--btn-bg': 'var(--color-info)' } as React.CSSProperties}
+>
+  Learn more
+</Button>
+
+// After — first-class semantic variant, picks up dark-mode overrides for free
 <Button color="info" type="button">Learn more</Button>
 ```
 
@@ -79,9 +234,20 @@ Brings Button to parity with Alert's semantic colors. No breaking change; existi
 
 Links now accept `disabled?: boolean`. The component applies `aria-disabled`, suppresses `href`, and blocks `onClick`/`onPointerDown` via the shared `useDisabledState` hook. The element stays in tab order so keyboard users still discover the disabled state (WCAG 2.1.1).
 
+**Upgrade steps**
+
 ```tsx
+// Before — app-level logic + conditional render, keyboard users can't
+// discover the disabled state because the link disappears
+{canEdit
+  ? <Link href="/settings">Edit settings</Link>
+  : <span className="link-disabled" aria-disabled="true">Edit settings</span>}
+
+// After — link stays in tab order, aria-disabled set, href + onClick suppressed
 <Link href="/settings" disabled={!canEdit}>Edit settings</Link>
 ```
+
+Why keep the element in tab order? WCAG 2.1.1 (Keyboard): every piece of functionality must be keyboard-operable *and discoverable*. Removing the link from the DOM hides the fact that it existed — a screen-reader user has no way to know "this action is temporarily unavailable."
 
 ### Alert — `data-alert` + `data-variant` documented exception (no change)
 
@@ -100,6 +266,18 @@ If you author SCSS overrides for Alert, no change is needed. A future release ma
 // After
 <Title level="h2">Section</Title>
 ```
+
+**Codemod** — find every call site to migrate:
+
+```bash
+# Imports
+rg "import\s+\{[^}]*Heading[^}]*\}\s+from\s+['\"]@fpkit/acss['\"]" src/
+
+# JSX usage — maps Heading type="h{n}" to Title level="h{n}"
+rg '<Heading\s+type=' src/
+```
+
+The prop rename is `type` → `level`; nothing else changes. `Title` is already WCAG AA compliant and ships the same size/color variants as `Heading`.
 
 ---
 

--- a/packages/fpkit/README.md
+++ b/packages/fpkit/README.md
@@ -4,8 +4,17 @@ A lightweight React UI library for building modern and accessible components tha
 
 [![npm version](https://badge.fury.io/js/@fpkit%2Facss.svg)](https://badge.fury.io/js/@fpkit%2Facss)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Design system v6](https://img.shields.io/badge/design--system-v6-blueviolet.svg)](docs/DESIGN-SYSTEM-v6.md)
 
 [📚 **Storybook Documentation**](https://fpkit.netlify.app/?path=/story/guides-introduction--page) | [🎯 **Component Playground**](https://fpkit.netlify.app/)
+
+## Design system
+
+As of v6.x, `@fpkit/acss` ships as a full design system — tokens, theming, CI gates, and a public docs site. Start with:
+
+- 📖 [Design System v6 Overview](docs/DESIGN-SYSTEM-v6.md) — narrative of everything shipped in v6.x.
+- 🗺️ [Documentation index](docs/README.md) — one-line-per-guide directory of all 13 guides.
+- ⬆️ [Migration guide](MIGRATION-v7.md) — per-change upgrade steps with before/after code.
 
 ## ✨ Features
 

--- a/packages/fpkit/docs/DESIGN-SYSTEM-v6.md
+++ b/packages/fpkit/docs/DESIGN-SYSTEM-v6.md
@@ -1,0 +1,217 @@
+# The @fpkit/acss Design System — v6.x Overview
+
+`@fpkit/acss` spent the v6.x line converting from a React component library into a full design system. This document is the narrative map: one read-through tells you what shipped, who it's for, and where to go next.
+
+If you want to *upgrade an existing app*, jump straight to [MIGRATION-v7.md](../MIGRATION-v7.md#minimum-viable-v6x-upgrade).
+
+If you want to *browse live tokens and components*, the Astro docs site at [apps/astro-builds/](../../../apps/astro-builds/) renders every foundation page from the token JSON.
+
+---
+
+## TL;DR
+
+Across seven phases, v6.x added:
+
+- **A token pipeline** — `@fpkit/acss/tokens` (DTCG-compliant JSON + typed TS module).
+- **A theming runtime** — `ThemeProvider`, `useTheme`, `ThemeToggle`, `getThemeFoucScript` for light/dark with system-preference tracking and SSR FOUC prevention.
+- **Governance** — `CONTRIBUTING.md`, component lifecycle stages, variant conventions, design-principles.
+- **CI quality gates** — Vitest coverage thresholds, `size-limit` bundle budgets, axe in Storybook test-runner, Chromatic visual regression, Changesets-driven releases.
+- **A public docs site** — Astro-based `apps/astro-builds/` with Foundations pages (data-driven from tokens) and a component maturity dashboard at `/status`.
+- **Component completion** — Link `disabled`, Button `color="info"`, Alert `info`, Fieldset, IconButton, dialog `icon`, responsive display utilities.
+
+Every change is additive. Nothing breaks in v6. Breaking changes are queued for v7.0.0 and tracked in [MIGRATION-v7.md](../MIGRATION-v7.md).
+
+### Phase timeline
+
+| Phase | Version | Theme | Commit |
+|---|---|---|---|
+| **1** | 6.0–6.2 | Governance + theme-ready color tokens (no hardcoded hex) | `3a290db` |
+| **2** | 6.2 | Design-token pipeline (`@fpkit/acss/tokens`) | `f8496ef` |
+| **3** | 6.3 | Theming runtime (`ThemeProvider`, `ThemeToggle`, FOUC script) | `6e9dfc6` |
+| **4** | 6.4 | Component completion (Link `disabled`, Button `color="info"`) + v7 migration scaffold | `56b8334` |
+| **5** | 6.5 | CI quality gates (coverage, size, a11y, Chromatic, Changesets) | `dcb7c22` |
+| **6** | 6.5–6.6 | Public Astro docs site (Foundations pages from tokens) | `01f926f` |
+| **7A** | 6.6 | Component maturity dashboard (`/status`) | `2f51db1` |
+
+> **Version column is illustrative** — phases landed in overlapping v6.x minors. Use `git log --oneline packages/fpkit/` for the exact per-commit history.
+
+---
+
+## What's new for consumers
+
+Everything below is additive — drop the new version in, adopt features at your own pace.
+
+### 🎨 Dark mode with zero per-component work
+
+Wrap your app once, get light/dark for every token-driven component:
+
+```tsx
+import { ThemeProvider, ThemeToggle } from '@fpkit/acss';
+
+<ThemeProvider defaultPreference="system">
+  <ThemeToggle />
+  {/* your app */}
+</ThemeProvider>
+```
+
+`ThemeProvider` watches `prefers-color-scheme` when preference is `"system"` and persists the user's choice to `localStorage`. `ThemeToggle` is an accessible cycler (light → dark → system); `useTheme()` gives you full programmatic control for custom pickers.
+
+**SSR apps (Astro, Next.js, Remix):** inline `getThemeFoucScript()` in `<head>` to prevent a flash of the wrong theme on first paint. See the [Theming guide](guides/theming.md#preventing-theme-flash-ssr) for framework-specific patterns.
+
+### 🎯 Design tokens you can import
+
+```ts
+// Raw values — good for Figma bridges, native platforms, docs sites
+import tokens from '@fpkit/acss/tokens';
+tokens.color.primary.$value;                                        // "#2563eb"
+tokens.color.primary.$extensions['com.fpkit.themeModes'].dark;      // "#3b82f6"
+
+// Typed var() references — good for React runtime (follows active theme)
+import { tokens } from '@fpkit/acss/tokens';
+tokens.color.primary;   // "var(--color-primary)"
+tokens.duration.base;   // "var(--duration-base)"
+```
+
+Categories shipped: primitive color scales (neutral, blue, green, red, amber, cyan), semantic colors with per-token dark overrides, motion durations + easings, responsive breakpoints. Typography and spacing tokens are on the roadmap.
+
+See the [Design Tokens guide](guides/design-tokens.md) for the full artifact shape, Figma/native consumption patterns, and the build pipeline.
+
+### ✨ New component APIs
+
+| Component | Added | Why |
+|---|---|---|
+| `Link` | `disabled?: boolean` | Keyboard-reachable disabled state (WCAG 2.1.1 compliant). Sets `aria-disabled`, suppresses `href` + `onClick`. |
+| `Button` | `color="info"` | Brings Button to parity with Alert's semantic colors. |
+| `Alert` | `info` variant | Completes the `error` / `success` / `warning` / `info` set. |
+| `Fieldset` | new component | Semantic `<fieldset>` + `<legend>` wrapper. |
+| `IconButton` | new component | Standalone icon button with accessible label (visually-hidden or responsive). |
+| `Dialog` | `icon` prop | Pass an IconButton trigger without manual wiring. |
+| `Button` | sizes `xl` / `2xl`, `block` | Full-width and very-large variants. |
+| — | responsive display utilities | `data-display` attributes for breakpoint-scoped show/hide. |
+
+Full per-change history with upgrade steps lives in [MIGRATION-v7.md](../MIGRATION-v7.md).
+
+### 🧩 Better custom-style integration
+
+The `--color-ui-overlay-base` token composes via `rgba(var(--color-ui-overlay-base), …)` so your hover/active overlays invert correctly under dark mode:
+
+```scss
+/* Before — dark mode ignores this */
+.my-card:hover { background: rgba(0, 0, 0, 0.08); }
+
+/* After — inverts automatically */
+.my-card:hover { background: var(--color-hover-overlay); }
+```
+
+---
+
+## What's new for contributors
+
+If you're working *on* the library rather than consuming it, four systems changed.
+
+### 🔒 CI quality gates
+
+Four new GitHub Actions workflows enforce the quality bar on every PR:
+
+- **`test.yml`** — lint, Vitest with coverage thresholds (lines 89, branches 90, functions 66, statements 89), `size-limit` budgets on built artifacts.
+- **`a11y.yml`** — Storybook test-runner + axe. Currently non-blocking (`continue-on-error: true`) while teams triage pre-existing violations.
+- **`chromatic.yml`** — visual regression. Gated on `CHROMATIC_PROJECT_TOKEN`; skips cleanly when unset.
+- **`release.yml`** — Changesets-driven. Opens a "Version Packages" PR on merge to `main`; publishes to npm when that PR merges.
+
+Bundle-size budgets (gzipped):
+- Main entry: 18 KB (baseline 15.5 KB)
+- Hooks subpath: 3 KB (baseline 2.33 KB)
+- Icons subpath: 6 KB (baseline 4.59 KB)
+- Compiled CSS: 18 KB (well above current ~14 KB gzipped baseline)
+
+Run locally before pushing:
+
+```bash
+cd packages/fpkit
+npm run lint && npm test && npm run test:coverage
+npm run build && npm run size
+```
+
+See the new [CI gates guide](guides/ci-gates.md) for threshold rationale, how to interpret reports, and when/how to flip non-blocking gates back to blocking.
+
+### 📦 Changesets for versioning
+
+Lerna no longer owns versioning. Add a changeset with `npx changeset`, pick the bump type, commit alongside your code. CI opens a Version Packages PR on merge to `main`; merging *that* PR publishes to npm. No manual `npm publish`, no forgotten changelog entries.
+
+The `lerna:version` / `lerna:publish` scripts still exist but exit 1 with a redirect message. Details in `.changeset/README.md`.
+
+### 📊 Component maturity dashboard
+
+`/status` (in the Astro site) renders every component's lifecycle stage + coverage signals, derived from Storybook meta at build time — no separate registry to maintain. Lifecycle vocabulary: `experimental` → `beta` → `rc` → `stable` → `deprecated`. Tag your component's `meta.tags` and the dashboard updates on next build.
+
+See the [Component Maturity Dashboard guide](guides/maturity-dashboard.md) for signal semantics (what counts as "a11y verified"? what counts as "dark-mode verified"?) and promotion criteria.
+
+### 📂 Plan-directory policy
+
+`CONTRIBUTING.md` now defines three canonical plan locations:
+
+- `openspec/changes/` — formal RFC-grade change proposals
+- `openspec/plans/` — long-lived implementation plans tied to approved proposals
+- `.claude/plans/` — short-lived working plans for in-flight tasks
+- ~~`docs/planning/`~~ — archived; one cross-cutting roadmap exception.
+
+See the [CONTRIBUTING guide](../../../CONTRIBUTING.md#where-to-file-plans-and-proposals) for the decision tree.
+
+---
+
+## Upgrading
+
+**Shortest path** — the [Minimum viable v6.x upgrade](../MIGRATION-v7.md#minimum-viable-v6x-upgrade) is five steps:
+
+1. `npm install @fpkit/acss@latest`
+2. Wrap your app in `ThemeProvider`, render a `ThemeToggle`.
+3. SSR only: inline `getThemeFoucScript()` in `<head>`.
+4. Replace hand-coded overlay colors with `var(--color-hover-overlay)` / `var(--color-active-overlay)`.
+5. Replace custom disabled-link logic with `<Link disabled={…}>`.
+
+Full per-change migration steps, before/after code snippets, and the v7-forward breakage list live in [MIGRATION-v7.md](../MIGRATION-v7.md).
+
+---
+
+## Where to learn more
+
+The canonical guides are markdown files under [`packages/fpkit/docs/guides/`](guides/). The public docs site at `apps/astro-builds/` renders versions of the most-visited guides for readers who prefer a browsable site.
+
+| Guide | What it covers | Audience |
+|---|---|---|
+| [design-principles.md](guides/design-principles.md) | The 7 principles (accessibility-first, tokens-as-contract, composition, etc.) | Both |
+| [architecture.md](guides/architecture.md) | Folder layout, build pipeline, exports | Contributors |
+| [design-tokens.md](guides/design-tokens.md) | `@fpkit/acss/tokens` shape, JSON + TS artifacts, Figma/native patterns | Both |
+| [theming.md](guides/theming.md) | `ThemeProvider`, `useTheme`, `ThemeToggle`, FOUC script, custom themes | Consumers |
+| [css-variables.md](guides/css-variables.md) | CSS variable naming standard, dark-mode composition | Both |
+| [variants.md](guides/variants.md) | Prop-vs-attribute policy for variants | Contributors |
+| [component-lifecycle.md](guides/component-lifecycle.md) | Promotion criteria for each lifecycle stage | Contributors |
+| [composition.md](guides/composition.md) | How components compose (Card + CardTitle + CardContent etc.) | Both |
+| [accessibility.md](guides/accessibility.md) | WCAG 2.1 AA checklist, keyboard + screen-reader patterns | Both |
+| [testing.md](guides/testing.md) | Vitest + RTL patterns, coverage expectations | Contributors |
+| [storybook.md](guides/storybook.md) | Story conventions, play functions, tags | Contributors |
+| [ci-gates.md](guides/ci-gates.md) | Coverage thresholds, bundle budgets, a11y gate, release flow | Contributors |
+| [maturity-dashboard.md](guides/maturity-dashboard.md) | `/status` signals, lifecycle tags, how to add a row | Contributors |
+
+Also useful:
+
+- [`MIGRATION-v7.md`](../MIGRATION-v7.md) — per-change upgrade steps with before/after code.
+- [`docs/css-variables.md`](../../../docs/css-variables.md) (root docs dir) — consumer-focused CSS variable reference.
+- [Astro docs site Foundations pages](../../../apps/astro-builds/src/pages/foundations/) — live views of every token (Colors, Typography, Spacing, Motion).
+- [Astro docs site `/status`](../../../apps/astro-builds/src/pages/status.astro) — component maturity dashboard.
+
+---
+
+## Known follow-ups
+
+Tracked as post-v6.x work:
+
+- **Typography + spacing tokens** in the pipeline. Today these live in `_type.scss` and component-scoped SCSS; future pass will extract them to `@fpkit/acss/tokens`.
+- **Storybook theme toolbar** for one-click light/dark switching during development (today: manual `data-theme` toggle in DevTools).
+- **Chromatic baselines for dark mode** — deferred until the `CHROMATIC_PROJECT_TOKEN` lands and the initial light baseline is approved.
+- **Docs-site axe gate** — `a11y.yml` covers component stories but not the Astro docs site. A follow-up gate will run axe against the built Astro pages.
+- **Flipping `a11y.yml` + `chromatic.yml` to blocking** once their baselines are green.
+
+---
+
+**Last updated:** v6.6.0 · **Roadmap source:** [`docs/planning/i-want-to-convert-nested-waffle.md`](../../../docs/planning/i-want-to-convert-nested-waffle.md) · **Feedback:** [GitHub Discussions](https://github.com/shawn-sandy/acss/discussions)

--- a/packages/fpkit/docs/README.md
+++ b/packages/fpkit/docs/README.md
@@ -2,6 +2,9 @@
 
 Welcome to the @fpkit/acss documentation! This collection of guides helps you build accessible, maintainable applications using the fpkit component library.
 
+> **New here?** Start with the [Design System v6 Overview](./DESIGN-SYSTEM-v6.md) — a one-page narrative of everything that shipped in v6.x.
+> **Upgrading?** Jump to the [minimum-viable upgrade checklist](../MIGRATION-v7.md#minimum-viable-v6x-upgrade).
+
 ---
 
 ## 📚 Guides
@@ -185,6 +188,42 @@ Understand the lifecycle tags (`experimental`, `beta`, `rc`, `stable`, `deprecat
 
 ---
 
+### [Component Maturity Dashboard Guide](./guides/maturity-dashboard.md)
+
+Understand the `/status` page — how signals are extracted from Storybook meta, what each column means, and how to tag a component so it shows up correctly.
+
+**Topics:**
+- Lifecycle vocabulary and how it maps to visual pills
+- Signal columns (Tests / A11y / Dark mode) — what each source of truth is
+- Tagging conventions (`tags: ["stable", "a11y-verified", "dark-mode-verified"]`)
+- Troubleshooting a component that shows as untagged or missing a signal
+
+**Use when:**
+- Tagging a new component's story
+- Debugging why the dashboard doesn't reflect your recent changes
+- Reviewing the dashboard before promoting a component
+
+---
+
+### [CI Quality Gates Guide](./guides/ci-gates.md)
+
+The CI gates that enforce code quality on every PR — coverage thresholds, bundle-size budgets, a11y audit, visual regression, and the Changesets release flow.
+
+**Topics:**
+- Coverage thresholds (lines 89%, branches 90%, functions 66%, statements 89%) — why these numbers, roadmap target
+- Bundle-size budgets per entry point with headroom and diagnostic tools (`npm run size:why`)
+- Non-blocking gates (axe, Chromatic) and the criteria to flip them to blocking
+- Changesets workflow: authoring a changeset, the Version Packages PR, release.yml
+- Pre-PR local checklist
+
+**Use when:**
+- A PR fails a CI gate and you need to diagnose
+- Tightening or relaxing a threshold
+- Understanding the release flow
+- Onboarding a new contributor
+
+---
+
 ## 🚀 Quick Start
 
 ### Installation
@@ -239,10 +278,19 @@ function App() {
 → Learn [Storybook Guide](./guides/storybook.md)
 
 **Promote a component from beta → stable (or author a new one)**
-→ Read [Component Lifecycle Guide](./guides/component-lifecycle.md) and check the [`/status` dashboard](../../../apps/astro-builds/src/pages/status.astro)
+→ Read [Component Lifecycle Guide](./guides/component-lifecycle.md) and the [Maturity Dashboard Guide](./guides/maturity-dashboard.md), then check the live [`/status` dashboard](../../../apps/astro-builds/src/pages/status.astro)
 
 **Understand fpkit patterns**
 → Start with [Architecture Guide](./guides/architecture.md)
+
+**My PR failed a CI gate**
+→ [CI Quality Gates Guide](./guides/ci-gates.md)
+
+**Upgrade my app to the latest v6.x**
+→ [Minimum-viable upgrade checklist](../MIGRATION-v7.md#minimum-viable-v6x-upgrade)
+
+**See everything that shipped in v6.x**
+→ [Design System v6 Overview](./DESIGN-SYSTEM-v6.md)
 
 ---
 
@@ -371,23 +419,28 @@ Found an issue or want to contribute? Visit our [GitHub repository](https://gith
 
 ```
 docs/
-├── README.md (this file)
+├── README.md                   - This index
+├── DESIGN-SYSTEM-v6.md         - Narrative overview of the v6.x conversion
 └── guides/
-    ├── theming.md              - Light/dark runtime and custom themes
+    ├── theming.md              - Light/dark runtime, custom themes, verification
     ├── design-tokens.md        - @fpkit/acss/tokens artifact and pipeline
     ├── css-variables.md        - Styling and customization
     ├── composition.md          - Component composition patterns
     ├── accessibility.md        - WCAG compliance and a11y
     ├── architecture.md         - Component structure and patterns
     ├── component-lifecycle.md  - Lifecycle stages and promotion criteria
+    ├── maturity-dashboard.md   - /status page signals and tagging conventions
+    ├── ci-gates.md             - Coverage, size, a11y, Chromatic, release flow
     ├── design-principles.md    - Design system principles
     ├── variants.md             - Variant authoring patterns
     ├── testing.md              - Testing strategies
     └── storybook.md            - Component documentation
 ```
 
+Also at the package root: [`../MIGRATION-v7.md`](../MIGRATION-v7.md) — per-change upgrade steps with before/after code.
+
 ---
 
-**Version**: 1.1.0
-**Last Updated**: 2026-04-17
+**Version**: 1.2.0
+**Last Updated**: 2026-04-19
 **License**: MIT

--- a/packages/fpkit/docs/guides/ci-gates.md
+++ b/packages/fpkit/docs/guides/ci-gates.md
@@ -1,0 +1,306 @@
+# CI Quality Gates
+
+Every PR to `@fpkit/acss` runs through four GitHub Actions workflows that enforce the quality bar. This guide explains what each gate checks, what the thresholds mean, how to pass them locally before pushing, and when/how to tighten or relax them.
+
+- [Overview](#overview)
+- [Coverage thresholds](#coverage-thresholds)
+- [Bundle-size budgets](#bundle-size-budgets)
+- [Accessibility (axe) gate](#accessibility-axe-gate)
+- [Visual regression (Chromatic)](#visual-regression-chromatic)
+- [Release flow (Changesets)](#release-flow-changesets)
+- [Local pre-PR checklist](#local-pre-pr-checklist)
+- [Docs-site gate — planned](#docs-site-gate--planned)
+
+---
+
+## Overview
+
+| Workflow | File | Blocks PR? | What it checks |
+|---|---|---|---|
+| `test.yml` | [.github/workflows/test.yml](../../../.github/workflows/test.yml) | ✅ blocking | Lint, Vitest with coverage thresholds, `size-limit` on built artifacts |
+| `a11y.yml` | [.github/workflows/a11y.yml](../../../.github/workflows/a11y.yml) | ⚠️ non-blocking (triage pass) | Storybook test-runner + axe across every story |
+| `chromatic.yml` | [.github/workflows/chromatic.yml](../../../.github/workflows/chromatic.yml) | ⚠️ non-blocking (no token yet) | Visual regression via Chromatic |
+| `release.yml` | [.github/workflows/release.yml](../../../.github/workflows/release.yml) | n/a — runs on `main` only | Opens Version Packages PR; publishes to npm on merge |
+
+The `deploy-docs.yml` workflow builds the Astro docs site and deploys to GitHub Pages on merge to `main`. It doesn't gate PRs.
+
+> **Why are two gates non-blocking?** Flipping a brand-new axe or Chromatic gate to blocking on day one surfaces *pre-existing* violations as red Xs, which drowns out the signal from actual regressions. Both gates run *today* (so violations show up in CI logs), and the plan is to flip them back to blocking once their baselines are green. See [below](#accessibility-axe-gate) and [visual regression](#visual-regression-chromatic) for the flip criteria.
+
+---
+
+## Coverage thresholds
+
+**Configured in** [`packages/fpkit/vitest.config.js`](../../vitest.config.js).
+
+| Metric | Threshold | Baseline at Phase 5 | Roadmap target |
+|---|---|---|---|
+| Lines | **89%** | 91.10% | 95%+ |
+| Branches | **90%** | 92.80% | 90%+ (already met) |
+| Functions | **66%** | 68.42% | 85%+ |
+| Statements | **89%** | 91.10% | 95%+ |
+
+### Why these numbers?
+
+Thresholds sit ~2 percentage points *below* the baseline captured when the gate first landed. Day-one CI wouldn't fail on routine additions, and the gate catches regressions of more than ~2pp without false alarms.
+
+**Excluded from coverage** (see `vitest.config.js`):
+
+- `src/tokens/**` — generated from SCSS; not application logic.
+- `src/components/fp.tsx` — legacy namespace shim, slated for removal.
+- `**/*.stories.tsx`, `**/*.test.tsx`, `node_modules/`, `src/test/**` — not production code.
+
+### Running coverage locally
+
+```bash
+cd packages/fpkit
+npm run test:coverage
+```
+
+Output: a text summary + HTML report at `coverage/index.html`. Open it to see which files are pulling the average down.
+
+### Interpreting the report
+
+The HTML report colour-codes:
+
+- **Green bars** — well above threshold.
+- **Yellow bars** — within 5pp of threshold. Watch-list.
+- **Red bars** — below threshold. Fails the gate.
+
+If a red bar is a *legitimately-uncoverable* surface (type-only branches, defensive `never` throws, catch-all fallbacks), add a focused `/* c8 ignore next */` comment with a reason — don't wholesale-exclude files.
+
+### Tightening the gate
+
+Raise the threshold in `vitest.config.js` when the baseline stabilizes ~2pp above the new target. Roadmap pace: ~1pp per quarter, aiming for lines 95+ / functions 85+ by the v7 release.
+
+---
+
+## Bundle-size budgets
+
+**Configured in** [`packages/fpkit/.size-limit.cjs`](../../.size-limit.cjs).
+
+| Entry point | Budget (gzipped) | Baseline | Headroom |
+|---|---|---|---|
+| `libs/index.js` (main, ESM) | 18 KB | 15.5 KB | ~15% |
+| `libs/hooks.js` | 3 KB | 2.33 KB | ~25% |
+| `libs/icons.js` | 6 KB | 4.59 KB | ~25% |
+| `libs/index.css` (compiled CSS) | 18 KB | ~14 KB gzipped (90 KB raw) | Comfortable |
+
+React + ReactDOM are excluded from main/hooks/icons (they're peer dependencies — consumers bring their own copy).
+
+### Why these numbers?
+
+Budgets sit ~15% above baseline. A new component of *modest* size slips in comfortably; a new 20 KB component hits the gate and requires deliberate review — either prove it's worth the budget via a MIGRATION note, or split it behind a subpath export.
+
+### Running size-limit locally
+
+Prerequisite: the library must be built first (artifacts come from `libs/`):
+
+```bash
+cd packages/fpkit
+npm run package && npm run sass:build
+npm run size
+```
+
+Output looks like:
+
+```
+  Size Limit
+  ~~~~~~~~~~~~~~~
+  @fpkit/acss (main entry, ESM): 15.52 kB with all dependencies, minified and gzipped
+  @fpkit/acss/hooks:             2.33 kB …
+  @fpkit/acss/icons:             4.59 kB …
+```
+
+### Diagnosing why a bundle grew
+
+```bash
+npm run size:why
+```
+
+Opens an interactive treemap in your browser. Hunt for:
+
+- **Unexpected transitive imports** — a hook that pulls in an entire component graph.
+- **Non-minified source files** — if CSS jumped, check whether a source `.scss` or unminified `.css` slipped into the compile.
+- **Large single files** — often a sign a component should split or defer via lazy import.
+
+### Recalibrating the budget
+
+Raise the limit only when:
+
+1. The growth is justified (new substantial feature, documented in a changeset).
+2. The baseline comment at the top of `.size-limit.cjs` is updated to match the new reality.
+3. You consider whether the new code belongs behind a subpath export instead of the main bundle.
+
+**CSS budget special note:** the compiled CSS budget has the most headroom today (14 KB vs 18 KB limit). Expect to revisit when Phase 6 foundation pages add more surface or new components ship.
+
+---
+
+## Accessibility (axe) gate
+
+**Workflow:** [`.github/workflows/a11y.yml`](../../../.github/workflows/a11y.yml). **Runner:** Storybook test-runner + `@axe-core/playwright` via `.storybook/test-runner.ts`.
+
+### What it checks
+
+Every Storybook story runs through axe. Violations print in CI logs. Since the gate is currently `continue-on-error: true`, failures *surface* but don't block merges — this lets us land Phase 3's dark-mode token changes (which uncover pre-existing contrast issues) without red-Xing every PR.
+
+### Opting a story out
+
+Some stories intentionally showcase broken or partial states (error boundaries, deliberately-invalid form demos). Opt those out per story:
+
+```tsx
+export const InvalidForm: Story = {
+  args: { /* … */ },
+  parameters: {
+    a11y: { disable: true },   // axe skips this story
+  },
+};
+```
+
+**Use sparingly.** An opt-out means the story ships without an a11y net. Prefer fixing the violation over opting out.
+
+### Running axe locally
+
+```bash
+cd packages/fpkit
+npm run test:a11y   # runs the Storybook test-runner against a built Storybook
+```
+
+Requires a built Storybook — start it with `npm run build-storybook` first, or run the test-runner against the dev server (see `test-runner.ts`).
+
+### Flipping to blocking
+
+Criteria to remove `continue-on-error: true` from `a11y.yml`:
+
+1. Every story either passes axe or has a documented opt-out.
+2. Three consecutive green CI runs on `main`.
+3. MIGRATION note added explaining the behaviour change (failing a11y now blocks merges).
+
+---
+
+## Visual regression (Chromatic)
+
+**Workflow:** [`.github/workflows/chromatic.yml`](../../../.github/workflows/chromatic.yml).
+
+### Current state
+
+The workflow is gated on the `CHROMATIC_PROJECT_TOKEN` repository secret:
+
+```yaml
+if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}
+```
+
+Until the token is populated, the job skips cleanly — no false red X, but no visual regression coverage either.
+
+Once the token lands, the job initially runs with `continue-on-error: true` so the first baseline capture doesn't block unrelated PRs.
+
+### Bringing the first baseline online
+
+1. Provision a Chromatic project, copy the project token.
+2. Add `CHROMATIC_PROJECT_TOKEN` to repo secrets (Settings → Secrets and variables → Actions).
+3. Merge a no-op PR to `main`. The workflow runs for the first time, uploads every story as a baseline, and links to the approval UI in the run output.
+4. Approve the initial baseline in the Chromatic UI.
+5. Subsequent PRs surface per-story visual diffs.
+
+### Flipping to blocking
+
+Remove `continue-on-error: true` from `chromatic.yml` once:
+
+1. The initial baseline is approved.
+2. Three consecutive CI runs show no unexpected diffs.
+3. Chromatic-specific parameters (viewports, delays for animation) are tuned per story where needed.
+
+### Dark-mode baselines
+
+The current baselines are light-mode only. Once dark-mode stories land, add `parameters: { chromatic: { modes: ['light', 'dark'] } }` to each story to capture paired snapshots. See the [theming troubleshooting section](theming.md#verification--troubleshooting).
+
+---
+
+## Release flow (Changesets)
+
+**Workflow:** [`.github/workflows/release.yml`](../../../.github/workflows/release.yml). **Config:** [`.changeset/config.json`](../../../.changeset/config.json). **Guide:** [`.changeset/README.md`](../../../.changeset/README.md).
+
+### Author flow (every PR with a user-visible change)
+
+```bash
+npx changeset
+```
+
+Interactive prompt: pick changed package, bump type (`patch` / `minor` / `major`), write a one-line summary. The CLI drops a markdown file in `.changeset/` that you commit alongside your code.
+
+### Release flow (maintainers)
+
+1. PRs with changesets merge to `main`.
+2. `release.yml` opens (or updates) a long-lived **"Version Packages"** PR that bumps versions and writes `CHANGELOG.md` entries for every pending changeset.
+3. Merge the Version Packages PR. The same workflow publishes to npm using the stored `NPM_TOKEN` secret.
+
+Two merges, one release. No manual `npm publish`, no hand-edited changelogs (they get clobbered on next release).
+
+### When to skip a changeset
+
+- Internal-only changes (CI tweaks, test refactors).
+- Changes that only touch `apps/astro-builds` (in the changesets `ignore` list).
+- Typo fixes in comments.
+
+When in doubt, default to `patch` for fixes, `minor` for additions. **`major` requires maintainer approval** and a migration note in [MIGRATION-v7.md](../MIGRATION-v7.md).
+
+### Why Changesets over Lerna?
+
+Lerna's version/publish was fragile in a mixed public/private monorepo. Changesets separates *declaring* a change (done by the PR author, who has context) from *applying* bumps (done by CI deterministically). The scripts `npm run lerna:version` / `npm run lerna:publish` still exist but exit 1 with a redirect message so muscle memory redirects to Changesets.
+
+---
+
+## Local pre-PR checklist
+
+Before pushing, run these from `packages/fpkit/`:
+
+```bash
+npm run lint                  # ESLint (catches most review nitpicks)
+npm test                      # Vitest unit tests
+npm run test:coverage         # Coverage thresholds
+npm run build                 # tokens → TS → SCSS → CSS
+npm run size                  # Bundle-size budgets
+```
+
+From monorepo root:
+
+```bash
+npm run build-storybook       # Catches story-level regressions
+npx changeset                 # If the PR has a user-visible change
+```
+
+Five minutes locally saves ten in CI + review back-and-forth.
+
+### Troubleshooting
+
+**Coverage fails in CI but passes locally**: check you ran against a clean build. Delete `coverage/` and re-run `npm run test:coverage` from a fresh state.
+
+**Size fails in CI but passes locally**: confirm you ran `npm run package && npm run sass:build` before `npm run size` — size-limit reads from `libs/`, not from source.
+
+**Changeset workflow says "no changeset found"**: if your PR is internal-only, the changesets action may still complain. Add an empty changeset with `npx changeset --empty` and a one-line summary.
+
+---
+
+## Docs-site gate — planned
+
+The current `a11y.yml` axe gate covers *component stories* in Storybook. It does **not** audit the Astro docs site at `apps/astro-builds/` (Foundations pages, `/status` dashboard, `/guides/*` pages).
+
+A follow-up gate will run `@axe-core/cli` against the built docs site. Until then, audit the Astro site manually before merging any PR that touches it:
+
+```bash
+cd apps/astro-builds
+npm run build
+npx http-server dist -p 4321
+# Open http://localhost:4321 in a browser, run axe DevTools extension
+```
+
+See the [Docs accessibility checklist](../../../CONTRIBUTING.md#docs-accessibility-checklist) in CONTRIBUTING.md for the full manual audit list.
+
+---
+
+## See also
+
+- [Component Maturity Dashboard guide](maturity-dashboard.md) — how `/status` derives its signals from Storybook meta.
+- [Testing guide](testing.md) — Vitest + React Testing Library patterns.
+- [Storybook guide](storybook.md) — story conventions, tags, play functions.
+- [Accessibility guide](accessibility.md) — the WCAG 2.1 AA bar these gates enforce.
+- [Design System v6 Overview](../DESIGN-SYSTEM-v6.md) — how the CI gates fit into the larger design-system conversion.

--- a/packages/fpkit/docs/guides/maturity-dashboard.md
+++ b/packages/fpkit/docs/guides/maturity-dashboard.md
@@ -1,0 +1,246 @@
+# Component Maturity Dashboard
+
+The `/status` page in the Astro docs site renders a live matrix of every component's lifecycle stage and coverage signals — no separate registry to maintain. The dashboard reads Storybook `meta` tags and filesystem state at build time. This guide explains what each signal means, how to tag a component correctly, and what triggers promotion between stages.
+
+- [What the dashboard shows](#what-the-dashboard-shows)
+- [Lifecycle vocabulary](#lifecycle-vocabulary)
+- [Signal columns — what each one means](#signal-columns--what-each-one-means)
+- [Tagging a component](#tagging-a-component)
+- [Promotion criteria](#promotion-criteria)
+- [Demoting or deprecating](#demoting-or-deprecating)
+- [Accessibility of the dashboard itself](#accessibility-of-the-dashboard-itself)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## What the dashboard shows
+
+**URL:** `/status` on the Astro docs site.
+**Source:** [`apps/astro-builds/src/pages/status.astro`](../../../apps/astro-builds/src/pages/status.astro).
+**Signal extraction:** [`apps/astro-builds/src/lib/component-status.ts`](../../../apps/astro-builds/src/lib/component-status.ts).
+
+The page is **build-time static** — no JS ships for this view. The `component-status` module walks `packages/fpkit/src/components/`, reads every `*.stories.tsx`, and parses:
+
+- `title:` — the Storybook title (used as the component's display name, last path segment).
+- `tags: [...]` — the lifecycle tag + any secondary signal tags.
+
+It also checks the filesystem for a sibling `*.test.tsx` next to each story.
+
+### What renders
+
+1. **Totals summary** — counts by lifecycle stage (Stable, RC, Beta, Experimental, Deprecated, Untagged) plus coverage totals.
+2. **Component matrix** — one row per story file, with columns: Component, Lifecycle, Tests, A11y, Dark mode, Other tags.
+
+Rows sort by lifecycle maturity (stable first → deprecated last → untagged), then alphabetically by name.
+
+---
+
+## Lifecycle vocabulary
+
+Five stages, used as Storybook tag values:
+
+| Stage | Tag value | What it means |
+|---|---|---|
+| **Experimental** | `experimental` | API may change without notice. Not production-ready. |
+| **Beta** | `beta` | API stable but incomplete. Missing tests, edge cases, or a11y polish. |
+| **RC** | `rc` | Release candidate. Feature-complete, awaiting soak time. |
+| **Stable** | `stable` | Production-ready. Breaking changes require major bumps. |
+| **Deprecated** | `deprecated` | Slated for removal. Do not use in new code. |
+
+> **Naming note:** Phase 7A renamed `alpha` → `experimental` to match common usage. If you see `alpha` in an old story, replace it with `experimental` on the next touch.
+
+Promotion criteria live in [component-lifecycle.md](component-lifecycle.md). This guide focuses on how the dashboard *reads* those tags, not on when you should promote.
+
+---
+
+## Signal columns — what each one means
+
+### Tests
+
+**Source:** Filesystem — does a sibling `*.test.tsx` exist next to the story?
+
+```
+src/components/button/
+├── button.tsx
+├── button.scss
+├── button.stories.tsx   ← dashboard reads this
+└── button.test.tsx      ← this file's presence = ✓ in the Tests column
+```
+
+**Gotchas:**
+
+- The check is *file presence only*. It doesn't verify the test file has meaningful coverage. Coverage numbers live in the [CI gates guide](ci-gates.md#coverage-thresholds).
+- A single `.test.tsx` with one `render()` assertion shows ✓ even if the component has 20 untested variants. Treat this signal as a *floor*, not a ceiling.
+- If your component has split files (e.g. `button.tsx` + `icon-button.tsx` sharing a directory), each story + test pair gets its own row. Don't worry about double-counting — the `name` field (from story `title`) disambiguates.
+
+### A11y
+
+**Source:** Does the story's `tags` array include `"a11y-verified"`?
+
+```tsx
+const meta = {
+  title: "FP.React Components/Buttons",
+  component: Button,
+  tags: ["stable", "a11y-verified"],   // ← ✓ in A11y column
+} as Meta;
+```
+
+**What "verified" means** — a maintainer has run the Storybook a11y addon against every variant, reviewed violations, and either fixed them or documented the opt-out. It is *not* automatic; the tag is a manual attestation.
+
+The non-blocking `a11y.yml` CI job (see [CI gates guide](ci-gates.md#accessibility-axe-gate)) surfaces violations but doesn't set this tag — you add it once you've reviewed and signed off.
+
+### Dark mode
+
+**Source:** Does the story's `tags` array include `"dark-mode-verified"`?
+
+```tsx
+tags: ["stable", "a11y-verified", "dark-mode-verified"]
+```
+
+**What "verified" means** — a maintainer has toggled `data-theme="dark"` on the story (via DevTools or the planned Storybook theme toolbar), confirmed every variant renders correctly (contrast, surface treatment, hover states), and captured Chromatic baselines for both modes (when available).
+
+See the [theming verification section](theming.md#verification--troubleshooting) for the manual verification procedure.
+
+### Other tags
+
+**Source:** Every tag in the `tags` array that isn't a lifecycle stage.
+
+Rendered as small chips. Common non-lifecycle tags in the repo:
+
+- `rc` — historical React Component indicator (may be redundant with lifecycle tags; kept for compatibility).
+- `a11y-verified`, `dark-mode-verified` — promoted to dedicated columns (duplicated in the chip list for visibility).
+- Custom tags you add per-project (e.g. `wip`, `compat-breaking`).
+
+---
+
+## Tagging a component
+
+Edit the component's `*.stories.tsx` `meta` object:
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Button from "./button";
+import "./button.scss";
+
+const meta = {
+  title: "FP.React Components/Buttons",
+  component: Button,
+  tags: [
+    "stable",                // lifecycle (required for the dashboard to show a stage)
+    "a11y-verified",         // opt-in signal
+    "dark-mode-verified",    // opt-in signal
+  ],
+  args: { /* … */ },
+} as Meta;
+
+export default meta;
+```
+
+### Minimum to appear on `/status`
+
+A story with **no tags at all** shows up as "untagged." Add at least a lifecycle tag so the dashboard can sort it.
+
+### Checking your tags render
+
+```bash
+cd apps/astro-builds
+npm run dev
+# Navigate to http://localhost:4321/status
+```
+
+The Astro dev server rebuilds on file changes — edit the story's tags, save, refresh. The dashboard updates immediately.
+
+### Verifying from the build
+
+```bash
+cd apps/astro-builds
+npm run build
+# Check dist/status/index.html
+```
+
+---
+
+## Promotion criteria
+
+Summary — see [component-lifecycle.md](component-lifecycle.md) for the full criteria:
+
+| Promotion | Requires |
+|---|---|
+| **Experimental → Beta** | Public API declared stable; tests present; at least one Storybook variant per prop |
+| **Beta → RC** | `a11y-verified` (audit passed); `dark-mode-verified`; coverage ≥ the CI threshold for this component |
+| **RC → Stable** | Two release cycles with no bug reports; full JSDoc on public props; Chromatic baselines for light + dark |
+
+**Dashboard-driven check:** before promoting, ensure the row shows ✓ in every relevant signal column. If a signal is missing, promotion is premature.
+
+---
+
+## Demoting or deprecating
+
+To mark a component **deprecated**:
+
+```tsx
+tags: ["deprecated"]    // removes it from "stable" count; shows red pill
+```
+
+Also:
+
+1. Add a JSDoc `@deprecated` tag to the component's props interface and main export.
+2. Open an entry in [MIGRATION-v7.md](../MIGRATION-v7.md) under the relevant section with the 💥 marker.
+3. Cross-link the replacement in the deprecation message.
+
+Example: `Heading` is deprecated; the replacement is `Title`. See the [Heading entry in MIGRATION-v7.md](../MIGRATION-v7.md#heading--still-deprecated--v7-candidate).
+
+To **demote** a stable component (regression, new bug surface): drop the lifecycle down by one stage (`stable` → `rc`) and add an `Other tag` noting why (e.g. `regression-under-investigation`). Don't silently remove the lifecycle tag.
+
+---
+
+## Accessibility of the dashboard itself
+
+The `/status` page is WCAG 2.1 AA compliant out of the box. Verified patterns:
+
+- **Semantic table** — `<table>` with `<thead>`, `<tbody>`, `<th scope="col">`. Not a `<div>` grid.
+- **Caption** — `<caption class="visually-hidden">` announces the table's purpose to screen readers.
+- **Lifecycle pills** — encode stage as **both** text ("stable", "experimental") and color. Color-blind users aren't left guessing.
+- **Signal cells** — `<span>` with `aria-label` for the signal state, plus a visible text symbol (`✓` or `—`). Screen readers announce "Has tests" / "No tests" explicitly.
+- **Tag chips** — plain text, no color-only meaning.
+- **Keyboard nav** — no interactive elements in the table; plain text only. Users tab through the site header's ThemeToggle and nav links.
+
+If you modify `status.astro`, preserve these patterns:
+
+- Don't encode any signal as color-alone.
+- Don't replace the semantic table with a CSS grid unless you add proper `role="table"` + `role="row"` + `role="columnheader"` + `role="cell"` attributes.
+- Keep the `aria-label` on signal spans — the symbols (`✓`, `—`) are decorative without context.
+
+---
+
+## Troubleshooting
+
+**Component doesn't appear on `/status`**
+Check: does the story file end in `.stories.tsx` (not `.stories.jsx` or `.story.tsx`)? The walker in `component-status.ts` matches `*.stories.tsx` exactly.
+
+**Component shows "untagged"**
+Add a lifecycle tag to `meta.tags`. If you already have one, confirm it's one of the five allowed values (`experimental`, `beta`, `rc`, `stable`, `deprecated`) — typos silently fall through.
+
+**Component shows wrong name**
+The name comes from the story's `title:`, taking the **last segment** after `/`. Example: `title: "FP.React Components/Buttons"` → name `"Buttons"`. If you want a different display name, rename the title.
+
+**A11y or Dark mode columns stay blank after I verified**
+The tags are `"a11y-verified"` and `"dark-mode-verified"` — spelled with hyphens, not underscores. Case-sensitive. Single typo → silent skip.
+
+**Tests column shows ✗ but I have tests**
+Two possibilities:
+1. The test file is named something other than `{story}.test.tsx`. The check is an exact filename match.
+2. The test lives in a subdirectory. `component-status.ts` looks for a sibling `.test.tsx`, not a nested one.
+
+**Dashboard didn't update after I edited a story**
+The Astro dev server should hot-reload. If it doesn't, stop the server and run `npm run dev` again — the `ensure-fpkit-build` prescript may have stale state.
+
+---
+
+## See also
+
+- [Component Lifecycle guide](component-lifecycle.md) — full criteria for each lifecycle stage.
+- [Storybook guide](storybook.md) — story conventions, meta object, play functions.
+- [CI gates guide](ci-gates.md) — how coverage thresholds relate to the Tests signal.
+- [Theming guide — verification section](theming.md#verification--troubleshooting) — the manual dark-mode verification procedure.
+- [Design System v6 Overview](../DESIGN-SYSTEM-v6.md) — how `/status` fits into the larger conversion.

--- a/packages/fpkit/docs/guides/maturity-dashboard.md
+++ b/packages/fpkit/docs/guides/maturity-dashboard.md
@@ -107,7 +107,6 @@ See the [theming verification section](theming.md#verification--troubleshooting)
 
 Rendered as small chips. Common non-lifecycle tags in the repo:
 
-- `rc` — historical React Component indicator (may be redundant with lifecycle tags; kept for compatibility).
 - `a11y-verified`, `dark-mode-verified` — promoted to dedicated columns (duplicated in the chip list for visibility).
 - Custom tags you add per-project (e.g. `wip`, `compat-breaking`).
 

--- a/packages/fpkit/docs/guides/theming.md
+++ b/packages/fpkit/docs/guides/theming.md
@@ -13,6 +13,7 @@ This guide covers:
 - [Creating a custom theme](#creating-a-custom-theme)
 - [API reference](#api-reference)
 - [Accessibility notes](#accessibility-notes)
+- [Verification & troubleshooting](#verification--troubleshooting)
 
 ---
 
@@ -256,6 +257,130 @@ All exports are available from the main barrel `@fpkit/acss`:
 - **No focus flash.** Because theme switching is a single attribute change on `<html>`, focus rings and component state don't flicker.
 - **No JS required for visual theming.** If JS is disabled, the page renders with the `:root` (light) theme and remains fully usable. Only the toggle and preference persistence require JS.
 - **Respect `prefers-reduced-motion`.** The runtime itself doesn't animate, but custom themes should ensure transitions on `color`/`background-color` honor the user's reduced-motion preference.
+
+---
+
+## Verification & troubleshooting
+
+A short checklist for verifying dark mode works correctly, plus the common issues teams hit when wiring the runtime into a new app.
+
+### Verifying dark mode in Storybook
+
+Until a Storybook theme toolbar addon ships (tracked as a Phase 3 follow-up), toggle dark mode manually from DevTools:
+
+```js
+// In the browser DevTools console while viewing any story:
+document.documentElement.setAttribute('data-theme', 'dark');
+
+// Back to light:
+document.documentElement.setAttribute('data-theme', 'light');
+```
+
+Every component that references semantic tokens (`--color-primary`, `--color-surface`, etc.) flips immediately. Step through every variant in your story — hover states, active states, focus rings, disabled appearance — and confirm:
+
+1. **Text contrast remains ≥ 4.5:1** against the new surface. Use the axe DevTools extension or WebAIM's contrast checker.
+2. **Focus indicators are still visible.** The default focus ring uses `currentColor`, which means it inherits whichever foreground color the component is using — double-check it doesn't blend into the new surface.
+3. **Semantic colors remain distinguishable.** Error / success / warning / info should still read as their intended emotion, not all converge to "slightly-different-gray."
+4. **Custom SCSS overrides still work.** If your story sets `--btn-bg: #custom` in `styles`, that hex value *won't* flip — that's the point of the override. Ensure the color you picked works in both themes.
+
+### Capturing Chromatic baselines for dark mode
+
+Once [`CHROMATIC_PROJECT_TOKEN`](ci-gates.md#visual-regression-chromatic) is populated and the initial light-mode baseline is approved, add dark-mode snapshots per story:
+
+```tsx
+export default {
+  component: Button,
+  parameters: {
+    chromatic: {
+      modes: ['light', 'dark'],
+    },
+  },
+} satisfies Meta;
+```
+
+Chromatic will capture one snapshot per mode. When you introduce a change that affects both themes, both baselines diff — a regression in just dark mode is caught without any extra work.
+
+**Baseline reset procedure** (if you accept a bulk theme change and want the current state to become the new baseline):
+
+1. Merge the PR with the change.
+2. In the Chromatic UI, navigate to the affected component.
+3. For each story, click **"Approve this change"** on the dark-mode diff (and light-mode, if both changed).
+4. The next run uses the approved snapshots as the baseline.
+
+Don't run `chromatic --auto-accept-changes` on `main` unless you've manually reviewed the changes — it approves *everything*, including regressions you didn't intend.
+
+### Common issues
+
+**FOUC still flashes even though I added `getThemeFoucScript()`**
+
+Most likely: your `ThemeProvider` and the FOUC script use different `storageKey` values. The script reads `localStorage['fpkit-theme-preference']` by default; if the provider uses a custom key, pass it to both:
+
+```tsx
+<ThemeProvider storageKey="my-app-theme">{children}</ThemeProvider>
+
+// And in <head>:
+getThemeFoucScript('my-app-theme');
+```
+
+Other suspects:
+
+- The script is in `<body>` instead of `<head>` — move it so it runs before any stylesheet loads.
+- The script is bundled (`<script type="module">`) instead of inline — `is:inline` (Astro) or `dangerouslySetInnerHTML` (React) is required.
+- A CSS-in-JS library is hydrating styles *before* the FOUC script runs — check your framework's script-ordering guarantees.
+
+**`useTheme()` throws "must be used inside a ThemeProvider"**
+
+The hook intentionally throws when called outside a provider. Common causes:
+
+- The provider is rendered *inside* the component that calls the hook (wrap higher up).
+- Two React trees (e.g. a portal, a separate `createRoot` call) — the provider only reaches its own subtree.
+- SSR hydration is swapping trees — confirm `ThemeProvider` is in the server-rendered output too.
+
+**Custom theme name isn't detected by `ThemeToggle`**
+
+Expected. `ThemeToggle` is a three-state cycler (`light` → `dark` → `system`); it doesn't know about `sepia` or any other custom theme. For apps with custom themes, compose your own picker with `useTheme()`:
+
+```tsx
+function ThemePicker() {
+  const { preference, setPreference } = useTheme();
+  return (
+    <select
+      value={preference}
+      onChange={(e) => setPreference(e.target.value as ThemePreference)}
+    >
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+      <option value="system">System</option>
+      {/* For a third custom theme, set data-theme directly on <html> — */}
+      {/* the provider only tracks the three built-in preferences. */}
+    </select>
+  );
+}
+```
+
+**Theme preference doesn't persist across page reloads**
+
+Check browser DevTools → Application → Local Storage. The key is `fpkit-theme-preference` (or your custom `storageKey`). If it's missing:
+
+- Third-party cookies / storage blocked (Safari ITP, strict privacy modes) — graceful fallback is to the `defaultPreference` prop.
+- `localStorage` quota exceeded (unusual but possible) — other code in the app may be writing large values.
+- SSR hydration mismatch wiping the attribute before the provider mounts — ensure `getThemeFoucScript()` runs before React hydrates.
+
+**Dark-mode colors look washed out**
+
+The semantic color mappings flip values between light and dark (e.g. primary goes from `#2563eb` → `#3b82f6`, a lighter blue for dark-mode legibility). If custom overrides look wrong under dark mode, you're probably overriding the *light value* and missing the dark one. Either:
+
+1. Set the override in `:root` only and accept the library's dark value.
+2. Add a matching override under `[data-theme="dark"]` in your CSS.
+
+```css
+:root {
+  --color-primary: #7c3aed;  /* your brand purple for light mode */
+}
+[data-theme="dark"] {
+  --color-primary: #a78bfa;  /* a lighter purple for dark mode */
+}
+```
 
 ---
 

--- a/packages/fpkit/docs/guides/theming.md
+++ b/packages/fpkit/docs/guides/theming.md
@@ -281,7 +281,7 @@ Every component that references semantic tokens (`--color-primary`, `--color-sur
 1. **Text contrast remains ≥ 4.5:1** against the new surface. Use the axe DevTools extension or WebAIM's contrast checker.
 2. **Focus indicators are still visible.** The default focus ring uses `currentColor`, which means it inherits whichever foreground color the component is using — double-check it doesn't blend into the new surface.
 3. **Semantic colors remain distinguishable.** Error / success / warning / info should still read as their intended emotion, not all converge to "slightly-different-gray."
-4. **Custom SCSS overrides still work.** If your story sets `--btn-bg: #custom` in `styles`, that hex value *won't* flip — that's the point of the override. Ensure the color you picked works in both themes.
+4. **Custom SCSS overrides still work.** If your story sets `--btn-bg: #7c3aed` in `styles`, that hex value *won't* flip — that's the point of the override. Ensure the color you picked works in both themes.
 
 ### Capturing Chromatic baselines for dark mode
 


### PR DESCRIPTION
## Summary

- Adds a single-page recap (`packages/fpkit/docs/DESIGN-SYSTEM-v6.md`) narrating what shipped across Phases 1–7A, so readers no longer have to reconstruct the story from ~30 scattered commits.
- Ships two new contributor guides — `ci-gates.md` (coverage thresholds, bundle budgets, a11y gate, Chromatic, Changesets flow) and `maturity-dashboard.md` (how `/status` signals are derived) — plus a Verification & troubleshooting section on `theming.md`.
- Expands `MIGRATION-v7.md` with a minimum-viable 5-step upgrade checklist and before/after code snippets for every change (ThemeProvider wire-up, token imports, Button `color="info"`, Link `disabled`, Heading → Title).
- Surfaces the guides on the public Astro docs site: new `/guides/{index,theming,tokens,migration}` pages + SiteHeader nav entry.
- Discoverability: docs-directory `README.md` index, canonical + OG tags in `Layout.astro`, sitemap integration scaffolded, shared `.vscode/css-custom-data.json` for token autocomplete, badges near top of root README.
- Accessibility: new **Docs accessibility checklist** in `CONTRIBUTING.md` enforcing WCAG 2.1 AA (heading hierarchy, descriptive link text, skip links, contrast under both themes, `prefers-reduced-motion`) for every future docs PR.

Documentation-only change — no library code or test behavior modified.

## Test plan

- [ ] `npx markdown-link-check` across all new/modified `.md` files — no broken cross-links
- [ ] `markdownlint` with rules MD001 / MD042 / MD045 passes on all new/modified docs
- [ ] `cd apps/astro-builds && npm run build` — `/guides/index`, `/guides/theming`, `/guides/tokens`, `/guides/migration` render in `dist/`
- [ ] `cd apps/astro-builds && npm run dev` — SiteHeader "Guides" link routes to `/guides/`; theme toggle still works on every new page
- [ ] axe DevTools pass on each new `/guides/*` page and each existing `/foundations/*` page in **both light and dark themes** — zero critical/serious violations
- [ ] Keyboard-only pass: skip link works on first tab; every interactive element reachable with visible focus; no traps
- [ ] Numbers in `ci-gates.md` reconciled against current `vitest.config.js` (Lines 89 / Branches 90 / Functions 66 / Statements 89) and `.size-limit.cjs` (main 18 / hooks 3 / icons 6 / CSS 18 KB gzipped)
- [ ] After merge: trigger `deploy-docs.yml` manually if it doesn't fire on merge, confirm `/guides/` section appears on the deployed site

https://claude.ai/code/session_01LcMf77ZypZDknBBzSft6tG