### PR TITLE
docs(planning): plan migration of plugins to shawn-sandy/acss-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "acss-plugins",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude Code plugins for building applications with @fpkit/acss React components",
   "owner": {
     "name": "Shawn Sandy",
@@ -11,10 +11,26 @@
     {
       "name": "fpkit-developer",
       "source": "./.claude/plugins/fpkit-developer",
-      "version": "0.1.6",
-      "description": "Guides development of applications built with @fpkit/acss React components. Use when composing custom components from fpkit primitives, validating or customizing CSS variables, extending fpkit components, or ensuring WCAG accessibility compliance.",
+      "version": "0.1.7",
+      "description": "Deprecated — superseded by acss-app-builder. Guides development of applications built with @fpkit/acss React components.",
       "category": "development",
-      "tags": ["fpkit", "acss", "react", "css-variables", "accessibility", "wcag", "component-composition"]
+      "tags": ["fpkit", "acss", "react", "css-variables", "accessibility", "wcag", "component-composition", "deprecated"]
+    },
+    {
+      "name": "acss-kit-builder",
+      "source": "./.claude/plugins/acss-kit-builder",
+      "version": "0.1.1",
+      "description": "Generate fpkit-style React components without installing @fpkit/acss. Reference-guided generation with CSS custom properties. Requires only React + sass.",
+      "category": "development",
+      "tags": ["fpkit", "acss", "react", "component-generation", "css-variables", "sass", "typescript"]
+    },
+    {
+      "name": "acss-app-builder",
+      "source": "./.claude/plugins/acss-app-builder",
+      "version": "0.1.1",
+      "description": "Scaffold apps with the @fpkit/acss design system: layouts, pages, themes, forms, patterns. Works with the @fpkit/acss npm package OR generated acss-kit-builder source.",
+      "category": "development",
+      "tags": ["fpkit", "acss", "react", "scaffolding", "forms", "layouts", "themes", "patterns"]
     }
   ]
 }

--- a/.claude/plugins/acss-app-builder/.claude-plugin/plugin.json
+++ b/.claude/plugins/acss-app-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-app-builder",
   "description": "Scaffold apps with the @fpkit/acss design system: layouts, pages, themes, forms, patterns. Works with the @fpkit/acss npm package OR generated acss-kit-builder source. Supersedes the deprecated fpkit-developer plugin.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/.claude/plugins/acss-app-builder/assets/forms/field-renderers.tsx
+++ b/.claude/plugins/acss-app-builder/assets/forms/field-renderers.tsx
@@ -3,7 +3,7 @@
 // These are NOT written to the developer's project; they document the rendering contract.
 //
 // All renderers use the real, verified exports from @fpkit/acss:
-//   Field, Input, Checkbox  — see packages/fpkit/src/index.ts
+//   Field, Input, Checkbox  — see https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts
 // Native <select> and <textarea> wrap inside <Field> because fpkit does not export wrappers.
 // {{IMPORT_SOURCE:Field,Input,Checkbox}}
 

--- a/.claude/plugins/acss-app-builder/skills/acss-app-builder/SKILL.md
+++ b/.claude/plugins/acss-app-builder/skills/acss-app-builder/SKILL.md
@@ -91,7 +91,7 @@ A single-skill workflow for scaffolding apps with the **@fpkit/acss** design sys
 2. If `name` omitted, derive PascalCase from template (e.g. `auth-login` → `AuthLogin`).
 3. Read `assets/pages/<template>.tsx`. If template file uses specific fpkit components, verify each against the active source:
    - For `generated`: check `<componentsDir>/<component>/<component>.tsx` exists. If missing, print `/kit-add <component>` hint and halt.
-   - For `npm`: assume the package exports from `packages/fpkit/src/index.ts`.
+   - For `npm`: assume the package exports from [`packages/fpkit/src/index.ts`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts).
 4. Substitute `{{IMPORT_SOURCE:...}}`, `{{NAME}}`, `{{ROUTE}}` tokens.
 5. Write to `src/pages/<Name>.tsx` (refuse without `--force` on conflict).
 6. Print wiring snippet for `src/App.tsx` or the developer's router.
@@ -206,7 +206,7 @@ A single-skill workflow for scaffolding apps with the **@fpkit/acss** design sys
 
 1. **No `@/` import aliases** — use relative imports.
 2. **Generated source wins on tie** — if `<componentsDir>/ui.tsx` exists, never import from `@fpkit/acss`.
-3. **Never invent exports** — the authoritative list is `packages/fpkit/src/index.ts`. Do not import `FieldLabel`, `FieldInput`, `Select`, or `Textarea` as named exports (they are not there).
+3. **Never invent exports** — the authoritative list is [`packages/fpkit/src/index.ts`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts). Do not import `FieldLabel`, `FieldInput`, `Select`, or `Textarea` as named exports (they are not there).
 4. **Refuse, don't overwrite** — require `--force` for any non-empty target.
 5. **Refuse on dirty tree** — require committed or stashed changes before mutating the project.
 6. **Sentinel blocks for entry mutation** — never use regex rewriting on `src/main.tsx`.

--- a/.claude/plugins/acss-app-builder/skills/acss-app-builder/references/component-source.md
+++ b/.claude/plugins/acss-app-builder/skills/acss-app-builder/references/component-source.md
@@ -39,7 +39,7 @@ import { Button, Card, Link } from '@fpkit/acss'
 import '@fpkit/acss/styles'
 ```
 
-## Verified exports (authoritative: `packages/fpkit/src/index.ts`)
+## Verified exports (authoritative: [`packages/fpkit/src/index.ts`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts))
 
 Do not invent imports. The package CLAUDE.md is out of date — `src/index.ts` is the source of truth.
 

--- a/.claude/plugins/acss-app-builder/skills/acss-app-builder/references/forms.md
+++ b/.claude/plugins/acss-app-builder/skills/acss-app-builder/references/forms.md
@@ -2,7 +2,7 @@
 
 Form generation from a JSON schema via `/app-form`.
 
-## The real Field API (verified at `packages/fpkit/src/components/form/fields.tsx`)
+## The real Field API (verified at [`packages/fpkit/src/components/form/fields.tsx`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/components/form/fields.tsx))
 
 ```tsx
 export const Field = ({ label, labelFor, children, ... }: FieldProps) => (

--- a/.claude/plugins/acss-kit-builder/.claude-plugin/plugin.json
+++ b/.claude/plugins/acss-kit-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-kit-builder",
   "description": "Generate fpkit-style React components without installing @fpkit/acss. Reference-guided generation with CSS custom properties. Requires only React + sass.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/.claude/plugins/acss-kit-builder/README.md
+++ b/.claude/plugins/acss-kit-builder/README.md
@@ -25,9 +25,22 @@ npm install -D sass
 
 ## Installation
 
-The plugin is already included in this repository at `.claude/plugins/acss-kit-builder/`. Claude Code auto-discovers plugins in `.claude/plugins/`.
+### Marketplace install (recommended)
 
-To use in another project, copy the entire `.claude/plugins/acss-kit-builder/` directory into the target project's `.claude/plugins/` folder.
+```shell
+/plugin marketplace add shawn-sandy/acss-plugins
+/plugin install acss-kit-builder@shawn-sandy-acss-plugins
+```
+
+### Manual install via GitHub clone
+
+```bash
+git clone https://github.com/shawn-sandy/acss-plugins.git
+mkdir -p ~/.claude/plugins/
+cp -r acss-plugins/acss-kit-builder ~/.claude/plugins/
+```
+
+For project-level install, substitute `~/.claude/plugins/` with `.claude/plugins/` inside your project.
 
 ## Commands
 

--- a/.claude/plugins/fpkit-developer/.claude-plugin/plugin.json
+++ b/.claude/plugins/fpkit-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpkit-developer",
   "description": "Guides development of applications built with @fpkit/acss React components. Provides component composition workflows, CSS variable validation, and WCAG accessibility guidance.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/.claude/plugins/fpkit-developer/README.md
+++ b/.claude/plugins/fpkit-developer/README.md
@@ -11,7 +11,7 @@
 > **Migrating:**
 >
 > 1. Uninstall the old plugin to avoid duplicate skills loading:
->    `/plugin uninstall fpkit-developer@shawn-sandy-acss`
+>    `/plugin uninstall fpkit-developer@shawn-sandy-acss-plugins`
 > 2. Install or enable `acss-app-builder`.
 > 3. Replace calls to `/fpkit-developer:fpkit-dev` with `/app-compose`.
 
@@ -47,13 +47,13 @@ This installs the plugin directly from the GitHub repository without cloning.
 **Step 1 — Add the marketplace:**
 
 ```shell
-/plugin marketplace add shawn-sandy/acss
+/plugin marketplace add shawn-sandy/acss-plugins
 ```
 
 **Step 2 — Install the plugin:**
 
 ```shell
-/plugin install fpkit-developer@shawn-sandy-acss
+/plugin install fpkit-developer@shawn-sandy-acss-plugins
 ```
 
 Claude Code copies the plugin to its local cache. Restart Claude Code when prompted.
@@ -61,13 +61,13 @@ Claude Code copies the plugin to its local cache. Restart Claude Code when promp
 **To update later:**
 
 ```shell
-/plugin marketplace update shawn-sandy-acss
+/plugin marketplace update shawn-sandy-acss-plugins
 ```
 
 **To uninstall:**
 
 ```shell
-/plugin uninstall fpkit-developer@shawn-sandy-acss
+/plugin uninstall fpkit-developer@shawn-sandy-acss-plugins
 ```
 
 ---
@@ -77,21 +77,21 @@ Claude Code copies the plugin to its local cache. Restart Claude Code when promp
 Clone the repository and copy the plugin manually.
 
 ```bash
-git clone https://github.com/shawn-sandy/acss.git
+git clone https://github.com/shawn-sandy/acss-plugins.git
 ```
 
 **User-level** (available across all your projects):
 
 ```bash
 mkdir -p ~/.claude/plugins/
-cp -r acss/.claude/plugins/fpkit-developer ~/.claude/plugins/
+cp -r acss-plugins/fpkit-developer ~/.claude/plugins/
 ```
 
 **Project-level** (this project only):
 
 ```bash
 mkdir -p .claude/plugins/
-cp -r acss/.claude/plugins/fpkit-developer .claude/plugins/
+cp -r acss-plugins/fpkit-developer .claude/plugins/
 ```
 
 ---
@@ -104,14 +104,14 @@ If you only need the skill without the plugin command:
 
 ```bash
 mkdir -p ~/.claude/skills/
-cp -r acss/.claude/plugins/fpkit-developer/skills/fpkit-developer ~/.claude/skills/
+cp -r acss-plugins/fpkit-developer/skills/fpkit-developer ~/.claude/skills/
 ```
 
 **Project-level:**
 
 ```bash
 mkdir -p .claude/skills/
-cp -r acss/.claude/plugins/fpkit-developer/skills/fpkit-developer .claude/skills/
+cp -r acss-plugins/fpkit-developer/skills/fpkit-developer .claude/skills/
 ```
 
 ---

--- a/docs/planning/acss-plugins-scaffolding/CLEAN-COPY.md
+++ b/docs/planning/acss-plugins-scaffolding/CLEAN-COPY.md
@@ -1,0 +1,104 @@
+# Clean-copy bootstrap (manual, no history preserved)
+
+This is the **simpler** of two paths to populate `shawn-sandy/acss-plugins`. It uses standard shell commands — no `git-filter-repo`, no `pip install`, no tooling beyond git itself. You lose the 7-commit per-plugin history, but keep all file content, functionality, and the Phase 1 prep work (version bumps, SKILL.md rewrites). Provenance is preserved by recording acss's current SHA in the initial commit message.
+
+The alternative path — `HANDOFF.md` — preserves git history using `git-filter-repo`. Pick that one if per-plugin blame matters to you.
+
+## Prerequisites
+
+1. Claude Code plugins branch checked out locally:
+   ```bash
+   cd ~/path/to/acss
+   git checkout claude/move-marketplace-plugins-repo-8kXL9
+   git pull origin claude/move-marketplace-plugins-repo-8kXL9
+   ```
+2. Empty repo created at `github.com/shawn-sandy/acss-plugins`. **Do not** initialize with README, LICENSE, or `.gitignore` — the first push expects an empty remote.
+
+## The recipe
+
+Run from your laptop. Replace `~/path/to/acss` with wherever your local acss clone lives.
+
+```bash
+# 1. Create a fresh directory for the new repo
+cd ~
+mkdir acss-plugins && cd acss-plugins
+
+# 2. Copy the plugin directories into the flat root layout
+ACSS=~/path/to/acss
+
+cp -r "$ACSS/.claude-plugin"                       .
+cp -r "$ACSS/.claude/plugins/acss-app-builder"     .
+cp -r "$ACSS/.claude/plugins/acss-kit-builder"     .
+cp -r "$ACSS/.claude/plugins/fpkit-developer"      .
+
+# 3. Apply the scaffolding files
+#    - marketplace.json replaces the copy carried over in step 2 (it has
+#      flat source paths like ./acss-app-builder instead of the original
+#      ./.claude/plugins/acss-app-builder)
+#    - the four other files are new at the root
+SCAFFOLD="$ACSS/docs/planning/acss-plugins-scaffolding"
+
+cp "$SCAFFOLD/marketplace.json"    .claude-plugin/marketplace.json
+cp "$SCAFFOLD/README.md"           README.md
+cp "$SCAFFOLD/CONTRIBUTING.md"     CONTRIBUTING.md
+cp "$SCAFFOLD/LICENSE"             LICENSE
+cp "$SCAFFOLD/gitignore.template"  .gitignore
+
+# 4. Sanity check — expect these exact root entries (order may differ)
+ls -A
+# Expected output:
+#   .claude-plugin  .gitignore  CONTRIBUTING.md  LICENSE  README.md
+#   acss-app-builder  acss-kit-builder  fpkit-developer
+
+# 5. Verify the flat source paths in marketplace.json
+grep '"source"' .claude-plugin/marketplace.json
+# Expected:
+#   "source": "./fpkit-developer",
+#   "source": "./acss-kit-builder",
+#   "source": "./acss-app-builder",
+
+# 6. Initialize, commit, and push
+git init -b main
+git add .
+
+# Record acss's current SHA so the commit message preserves provenance
+ACSS_SHA=$(git -C "$ACSS" rev-parse HEAD)
+
+git commit -m "chore: initial commit — extracted from shawn-sandy/acss@${ACSS_SHA}
+
+Plugins (acss-app-builder, acss-kit-builder, fpkit-developer) were
+copied from shawn-sandy/acss .claude/plugins/<name>/ and moved to the
+repo root. marketplace.json rewritten with flat source paths (./<name>
+instead of ./.claude/plugins/<name>). Top-level README, CONTRIBUTING,
+LICENSE, and .gitignore added.
+
+See shawn-sandy/acss@${ACSS_SHA}:docs/planning/we-need-to-move-distributed-porcupine.md
+for the full migration plan, stress-test findings, and rationale."
+
+git remote add origin https://github.com/shawn-sandy/acss-plugins.git
+git push -u origin main
+```
+
+## After the push
+
+1. Visit https://github.com/shawn-sandy/acss-plugins and confirm the tree:
+   ```
+   .claude-plugin/marketplace.json
+   acss-app-builder/
+   acss-kit-builder/
+   fpkit-developer/
+   README.md
+   CONTRIBUTING.md
+   LICENSE
+   .gitignore
+   ```
+2. Ping Claude in the acss session — one-liner like "acss-plugins pushed" — and Phase 3 (redirect stub + cleanup in this acss repo) will kick off on the same `claude/move-marketplace-plugins-repo-8kXL9` branch.
+
+## If something goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `git push` rejected: "remote contains work" | New repo accidentally got a README/LICENSE/.gitignore on creation | `git pull --rebase origin main` to merge, or delete + recreate the empty repo |
+| `cp: cannot stat ...`: source file not found | `ACSS` points to the wrong path, or you're not on the right branch | `echo $ACSS` and `git -C $ACSS branch --show-current` — the latter should read `claude/move-marketplace-plugins-repo-8kXL9` |
+| `ls -A` shows unexpected files (e.g. `.DS_Store`, editor cruft) | Cruft accidentally copied over from `$ACSS` | `.gitignore` will suppress `.DS_Store`; anything else, delete before `git add .` |
+| Commit signing fails on your laptop | Local git config has `commit.gpgsign = true` but no working signing key | Set up your signing key, or run the single commit with `git -c commit.gpgsign=false commit ...` (your explicit one-time choice) |

--- a/docs/planning/acss-plugins-scaffolding/CONTRIBUTING.md
+++ b/docs/planning/acss-plugins-scaffolding/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to acss-plugins
+
+This repo hosts the Claude Code plugins for `@fpkit/acss`. The live fpkit source lives in a separate repo: [`shawn-sandy/acss`](https://github.com/shawn-sandy/acss).
+
+## Sibling-clone workflow
+
+Plugin work often needs to reference the fpkit source — either to check what's exported, review a component's implementation, or verify a CSS variable naming convention. Keep both repos cloned as siblings:
+
+```
+~/work/
+├── acss/               # shawn-sandy/acss — live fpkit library
+└── acss-plugins/       # this repo
+```
+
+The plugins do not assume this layout at runtime. All references to fpkit source in `SKILL.md` files and generated-code comments use full GitHub URLs (e.g. `https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts`) so plugin users need only this repo to be installed.
+
+The sibling layout is for **contributors** editing plugin skill docs: open the fpkit source locally, verify the current exports, then update the plugin reference docs to match.
+
+## Repo structure
+
+```
+acss-plugins/
+├── .claude-plugin/
+│   └── marketplace.json    # catalog listing all plugins
+├── acss-app-builder/       # scaffolding plugin
+├── acss-kit-builder/       # component generator plugin
+├── fpkit-developer/        # deprecated; kept for one release
+├── README.md
+├── CONTRIBUTING.md
+└── LICENSE
+```
+
+Each plugin directory follows the Claude Code plugin convention:
+- `.claude-plugin/plugin.json` — manifest (name, version, description)
+- `README.md` — user-facing docs
+- `commands/*.md` — slash command definitions
+- `skills/<plugin>/SKILL.md` — skill definition invoked by Claude
+- `skills/<plugin>/references/` — knowledge base documents
+- `assets/` — templates and code snippets used by the plugin
+
+## Version bumps
+
+Plugin versions live in two places:
+- `<plugin>/.claude-plugin/plugin.json` — **authoritative** (Claude Code reads this silently when plugins are installed via this repo directly or via git-subdir from the legacy redirect)
+- `.claude-plugin/marketplace.json` plugin entries — **omit version here** to avoid conflict (per Claude Code docs: "The plugin manifest always wins silently")
+
+Bump the version in `plugin.json` when shipping changes — `/plugin update` uses it to detect new versions.
+
+## Testing locally
+
+```bash
+# In a disposable project or a Claude Code test session:
+/plugin marketplace add /absolute/path/to/acss-plugins
+/plugin install acss-app-builder@<local-marketplace-name>
+```
+
+Local-path marketplaces work the same as git-hosted ones. When satisfied, push to GitHub and let users install from `shawn-sandy/acss-plugins`.
+
+## Before submitting a change
+
+1. `plugin.json` version bumped
+2. SKILL.md references to fpkit source are full GitHub URLs, not repo-relative paths
+3. `marketplace.json` description reflects any user-facing change
+4. Relevant `README.md` (plugin-level or repo-level) updated

--- a/docs/planning/acss-plugins-scaffolding/HANDOFF.md
+++ b/docs/planning/acss-plugins-scaffolding/HANDOFF.md
@@ -1,0 +1,127 @@
+# acss-plugins repo scaffolding
+
+This directory contains everything needed to bootstrap the new `shawn-sandy/acss-plugins` repo from a fresh extraction of this `shawn-sandy/acss` repo. The files here mirror what should end up at the **root** of the new repo.
+
+## Files
+
+| File | Goes where in the new repo | Notes |
+|---|---|---|
+| `README.md` | `/README.md` | Public-facing overview |
+| `CONTRIBUTING.md` | `/CONTRIBUTING.md` | Sibling-clone dev workflow |
+| `LICENSE` | `/LICENSE` | MIT, mirrors plugin manifests |
+| `gitignore.template` | `/.gitignore` | **Rename on copy** (drop `.template`, add leading dot) |
+| `marketplace.json` | `/.claude-plugin/marketplace.json` | **Replaces** the file carried over by filter-repo (rewrites source paths from `./.claude/plugins/<name>` to `./<name>`, drops per-entry versions, bumps to 0.2.0) |
+
+## Step-by-step: bootstrap the new repo from your laptop
+
+### Prerequisites
+
+```bash
+# 1. Create empty repo at github.com/shawn-sandy/acss-plugins
+#    - Do NOT initialize with README, .gitignore, or LICENSE.
+#    - The first push expects an empty remote.
+
+# 2. Install git-filter-repo (skip if already installed)
+pip3 install --user git-filter-repo
+which git-filter-repo   # should print a path
+```
+
+### Clone acss and re-run the deterministic extraction
+
+The extraction is byte-deterministic: same input commits + same flags → identical output. You can run this from any laptop.
+
+```bash
+# Pull this branch into your local acss clone
+cd ~/path/to/acss
+git checkout claude/move-marketplace-plugins-repo-8kXL9
+git pull origin claude/move-marketplace-plugins-repo-8kXL9
+
+# Clone a mirror to a working directory; never filter-repo the active clone
+cd ~/   # or wherever you want the new repo's parent
+git clone --no-local ~/path/to/acss acss-plugins-extract
+cd acss-plugins-extract
+
+# Filter to plugin files only and rename them up to root
+git filter-repo --force \
+  --path .claude-plugin/ \
+  --path .claude/plugins/acss-app-builder/ \
+  --path .claude/plugins/acss-kit-builder/ \
+  --path .claude/plugins/fpkit-developer/ \
+  --path-rename .claude/plugins/acss-app-builder/:acss-app-builder/ \
+  --path-rename .claude/plugins/acss-kit-builder/:acss-kit-builder/ \
+  --path-rename .claude/plugins/fpkit-developer/:fpkit-developer/
+
+# Quick verification — these should match
+find . -type f -not -path './.git/*' | wc -l   # → 87
+git log --oneline | wc -l                       # → 7
+ls                                              # → .claude-plugin acss-app-builder acss-kit-builder fpkit-developer
+```
+
+### Apply the scaffolding files
+
+From inside `acss-plugins-extract/`:
+
+```bash
+# Replace the carried-over marketplace.json with the rewritten one,
+# then drop in the four new top-level files
+SCAFFOLD=~/path/to/acss/docs/planning/acss-plugins-scaffolding
+
+cp "$SCAFFOLD/marketplace.json"     .claude-plugin/marketplace.json
+cp "$SCAFFOLD/README.md"            README.md
+cp "$SCAFFOLD/CONTRIBUTING.md"      CONTRIBUTING.md
+cp "$SCAFFOLD/LICENSE"              LICENSE
+cp "$SCAFFOLD/gitignore.template"   .gitignore
+
+# Verify the marketplace.json source paths and root listing
+grep '"source"' .claude-plugin/marketplace.json
+ls -la
+```
+
+Expected source paths after the copy:
+```
+"source": "./fpkit-developer",
+"source": "./acss-kit-builder",
+"source": "./acss-app-builder",
+```
+
+Expected root listing: `.claude-plugin/  .gitignore  CONTRIBUTING.md  LICENSE  README.md  acss-app-builder/  acss-kit-builder/  fpkit-developer/`
+
+### Commit, rename branch, push
+
+```bash
+git add README.md CONTRIBUTING.md LICENSE .gitignore .claude-plugin/marketplace.json
+git status   # should show 5 changes ready
+
+git commit -m "chore: initial standalone-repo scaffolding
+
+Added after git filter-repo extraction from shawn-sandy/acss:
+- README.md, CONTRIBUTING.md, LICENSE, .gitignore (top-level)
+- Rewrote marketplace.json source paths from ./.claude/plugins/<name>
+  to ./<name> to match the new flat repo layout.
+- Bumped marketplace version to 0.2.0.
+- Removed redundant per-plugin version fields from marketplace.json
+  (plugin.json always wins silently per Claude Code docs)."
+
+# Rename branch to main; the inherited branch name is the source repo's feature branch
+git branch -m main
+
+# Wire up remote and push
+git remote add origin https://github.com/shawn-sandy/acss-plugins.git
+git push -u origin main
+```
+
+## After the push
+
+1. Visit `https://github.com/shawn-sandy/acss-plugins` and confirm the tree looks right
+2. Tell Claude (in the acss session) "acss-plugins pushed" — it will start Phase 3 (redirect stub + cleanup) on the same `claude/move-marketplace-plugins-repo-8kXL9` branch
+3. Phase 4 verification (Claude can guide): in a fresh Claude Code session, `/plugin marketplace add shawn-sandy/acss-plugins` and confirm the install footprint is dramatically smaller than `shawn-sandy/acss`
+
+## If something goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `git push` rejected, "remote contains work" | New repo accidentally got a README/LICENSE on creation | `git pull --rebase origin main` then `git push`, or delete + recreate the empty repo |
+| Filter-repo `--force` warning | You're running on the source clone instead of a mirror | Re-do `git clone --no-local` to a fresh dir |
+| `git-filter-repo: command not found` | `~/.local/bin` not on PATH | `export PATH="$HOME/.local/bin:$PATH"` then re-run, or use `python3 -m git_filter_repo ...` |
+| File counts don't match (87 / 7) | Possible drift in the source branch since this scaffolding was created | Compare `git log` on the feature branch — confirm `f3a4c31` is HEAD; if newer commits added plugin files, the count grows accordingly |
+| Commit signing fails on your laptop | Local git config has `commit.gpgsign = true` but no key | Set up your signing key, or run `git -c commit.gpgsign=false commit ...` (one-time, your explicit choice) |

--- a/docs/planning/acss-plugins-scaffolding/HANDOFF.md
+++ b/docs/planning/acss-plugins-scaffolding/HANDOFF.md
@@ -2,7 +2,14 @@
 
 This directory contains everything needed to bootstrap the new `shawn-sandy/acss-plugins` repo from a fresh extraction of this `shawn-sandy/acss` repo. The files here mirror what should end up at the **root** of the new repo.
 
-## Files
+## Which path to follow
+
+Two parallel recipes, same end state:
+
+- **[`CLEAN-COPY.md`](./CLEAN-COPY.md) — recommended for most users.** Plain `cp -r` + `git init`. No new tooling. Loses the 7-commit per-plugin history; preserves provenance via the initial commit message.
+- **`HANDOFF.md` (this file) — history-preserving.** Uses `git-filter-repo` to carry per-plugin commit history into the new repo. Requires `pip install git-filter-repo`. Pick this if you want `git blame` and `git log` to show the full evolution of each plugin file.
+
+## Files (used by both recipes)
 
 | File | Goes where in the new repo | Notes |
 |---|---|---|

--- a/docs/planning/acss-plugins-scaffolding/LICENSE
+++ b/docs/planning/acss-plugins-scaffolding/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Shawn Sandy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/planning/acss-plugins-scaffolding/README.md
+++ b/docs/planning/acss-plugins-scaffolding/README.md
@@ -1,0 +1,29 @@
+# acss-plugins
+
+Claude Code plugins for building applications with [@fpkit/acss](https://github.com/shawn-sandy/acss) React components.
+
+## Plugins in this marketplace
+
+| Plugin | Purpose |
+|---|---|
+| [`acss-app-builder`](./acss-app-builder) | Scaffold apps with the fpkit design system — layouts, pages, themes, forms, patterns. Works with the `@fpkit/acss` npm package OR generated source. |
+| [`acss-kit-builder`](./acss-kit-builder) | Generate fpkit-style React components directly into your project — no `@fpkit/acss` npm install required. |
+| [`fpkit-developer`](./fpkit-developer) | **Deprecated** — superseded by `acss-app-builder`. Kept for one release cycle. |
+
+## Install
+
+```shell
+/plugin marketplace add shawn-sandy/acss-plugins
+/plugin install acss-app-builder@shawn-sandy-acss-plugins
+/plugin install acss-kit-builder@shawn-sandy-acss-plugins
+```
+
+## Relationship to the main fpkit repo
+
+Plugin development references the live fpkit source at [`shawn-sandy/acss`](https://github.com/shawn-sandy/acss). Contributors should keep both repos available side-by-side — see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the workflow.
+
+SKILL.md files and reference docs in each plugin link to specific fpkit source files via full GitHub URLs, so plugin authors can click through without a local clone.
+
+## License
+
+MIT

--- a/docs/planning/acss-plugins-scaffolding/gitignore.template
+++ b/docs/planning/acss-plugins-scaffolding/gitignore.template
@@ -1,0 +1,10 @@
+node_modules/
+.DS_Store
+*.log
+.env
+.env.*
+!.env.example
+.vscode/
+.idea/
+*.tmp
+*.swp

--- a/docs/planning/acss-plugins-scaffolding/marketplace.json
+++ b/docs/planning/acss-plugins-scaffolding/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "acss-plugins",
+  "version": "0.2.0",
+  "description": "Claude Code plugins for building applications with @fpkit/acss React components",
+  "owner": {
+    "name": "Shawn Sandy",
+    "url": "https://github.com/shawn-sandy/acss-plugins"
+  },
+  "plugins": [
+    {
+      "name": "fpkit-developer",
+      "source": "./fpkit-developer",
+      "description": "Deprecated — superseded by acss-app-builder. Guides development of applications built with @fpkit/acss React components.",
+      "category": "development",
+      "tags": ["fpkit", "acss", "react", "css-variables", "accessibility", "wcag", "component-composition", "deprecated"]
+    },
+    {
+      "name": "acss-kit-builder",
+      "source": "./acss-kit-builder",
+      "description": "Generate fpkit-style React components without installing @fpkit/acss. Reference-guided generation with CSS custom properties. Requires only React + sass.",
+      "category": "development",
+      "tags": ["fpkit", "acss", "react", "component-generation", "css-variables", "sass", "typescript"]
+    },
+    {
+      "name": "acss-app-builder",
+      "source": "./acss-app-builder",
+      "description": "Scaffold apps with the @fpkit/acss design system: layouts, pages, themes, forms, patterns. Works with the @fpkit/acss npm package OR generated acss-kit-builder source.",
+      "category": "development",
+      "tags": ["fpkit", "acss", "react", "scaffolding", "forms", "layouts", "themes", "patterns"]
+    }
+  ]
+}

--- a/docs/planning/we-need-to-move-distributed-porcupine.md
+++ b/docs/planning/we-need-to-move-distributed-porcupine.md
@@ -22,6 +22,56 @@ We also want the new plugin repo to reference the current `shawn-sandy/acss` rep
 | Bidirectional reference | Full GitHub URLs in plugin docs (no sibling-clone dependency) |
 | Cleanup scope | Delete `.claude/plugins/` and root stale zips only; keep standalone skill, `downloads/`, and historical planning docs |
 
+## Execution status (as of 2026-04-21)
+
+**✅ Phase 1 complete** — commit `f3a4c31` on `claude/move-marketplace-plugins-repo-8kXL9`, pushed to origin:
+- All three plugins registered in `/home/user/acss/.claude-plugin/marketplace.json`
+- Plugin versions bumped (`fpkit-developer` 0.1.7, `acss-kit-builder` 0.1.1, `acss-app-builder` 0.1.1)
+- `fpkit-developer/README.md` and `acss-kit-builder/README.md` install instructions rewritten for `shawn-sandy/acss-plugins`
+- SKILL.md + reference docs repo-relative paths rewritten to full GitHub URLs
+
+**✅ Phase 0 step 3b (schema verification) complete** — docs confirm `git-subdir` source type supports subdirectory targeting with sparse clone. Transparent-redirect strategy validated.
+
+**🟡 Phase 2 partially complete** — local extraction to `/tmp/acss-plugins-extract` done, ready for push once remote repo exists:
+- `git-filter-repo` installed at `~/.local/bin/git-filter-repo`
+- `git clone --no-local /home/user/acss /tmp/acss-plugins-extract` done
+- Filter applied: 62 commits → 7 commits (just the plugin-touching ones), paths renamed to root
+- Pre-push checkpoint passed: 91 files, 9 root entries, all source paths rewritten to `./<name>`, all 3 plugin.json manifests intact
+- Scaffolding files added and staged (not yet committed — the commit-signing server in this sandbox rejects commits from `/tmp/` paths): `README.md`, `CONTRIBUTING.md`, `LICENSE`, `.gitignore`, updated `marketplace.json`
+- Current branch in extract: `claude/move-marketplace-plugins-repo-8kXL9` (needs rename to `main`)
+
+### Handoff: to finish Phase 2
+
+Run these on a machine where commit signing works (the user's laptop or a CI environment that shares this sandbox's signing identity):
+
+```bash
+# 1. Create the remote repo at github.com/shawn-sandy/acss-plugins (empty, no README/LICENSE)
+
+# 2. Commit the staged scaffolding
+cd /tmp/acss-plugins-extract
+git status    # should show 5 staged files ready
+git commit -m "$(cat <<'EOF'
+chore: initial standalone-repo scaffolding
+
+Added after git filter-repo extraction from shawn-sandy/acss:
+- README.md, CONTRIBUTING.md, LICENSE, .gitignore (top-level)
+- Rewrote marketplace.json source paths from ./.claude/plugins/<name>
+  to ./<name> to match the new flat repo layout.
+- Bumped marketplace version to 0.2.0.
+- Removed redundant per-plugin version fields from marketplace.json
+  (plugin.json always wins silently per Claude Code docs).
+- Updated owner.url to this repo's URL.
+EOF
+)"
+
+# 3. Rename branch to main and set up remote
+git branch -m claude/move-marketplace-plugins-repo-8kXL9 main
+git remote add origin https://github.com/shawn-sandy/acss-plugins.git
+git push -u origin main
+```
+
+Once `shawn-sandy/acss-plugins` is live, proceed to Phase 3 in the main acss repo.
+
 ## Stress-test findings (incorporated into plan below)
 
 Gaps and assumptions caught during review; each maps to a concrete plan change:
@@ -92,7 +142,19 @@ acss-plugins/
 2. Install `git-filter-repo`: `pip install git-filter-repo`.
 3. Confirm working tree clean: `git status` in `/home/user/acss`.
 3a. **Marketplace keying + double-subscribe smoke test** (resolves stress-test findings #5, #6): in a disposable Claude Code session, `/plugin marketplace add shawn-sandy/acss`, then manually add a second marketplace with the same internal `name` field (e.g., a temporary fork) and run `/plugin marketplace list`. Confirm Claude Code keys by repo slug, not `name`. If it keys by `name`, abandon the transparent-redirect strategy and fall back to hard cutover.
-3b. **Marketplace schema verification** (resolves stress-test finding #7): fetch `https://anthropic.com/claude-code/marketplace.schema.json`. Confirm the `plugins[].source` field accepts an object form `{ "source": "github", "repo": "...", "path": "..." }`. If it only accepts relative strings, halt: the transparent-redirect strategy is unworkable and must be replaced with hard cutover before any Phase 1 work begins.
+3b. **Marketplace schema verification** — **✅ RESOLVED on 2026-04-21** (stress-test finding #7). Docs at <https://code.claude.com/docs/en/plugin-marketplaces#plugin-sources> confirm five `source` types. For the redirect strategy the correct type is **`git-subdir`**, not `github`:
+    ```json
+    "source": {
+      "source": "git-subdir",
+      "url": "https://github.com/shawn-sandy/acss-plugins.git",
+      "path": "acss-app-builder"
+    }
+    ```
+    `git-subdir` "clones sparsely to minimize bandwidth for monorepos" — so users of the redirect stub automatically get the ~600 KB sparse clone instead of full-repo download. The install-size goal is achieved for existing users even without re-adding the new marketplace.
+3c. **Version field placement** (new, from schema docs): the docs warn "The plugin manifest always wins silently…For relative-path plugins, set the version in the marketplace entry. For all other plugin sources, set it in the plugin manifest." Accordingly:
+    - New repo (`acss-plugins`, relative-path sources): version belongs in **marketplace entry only**, remove from individual `plugin.json` files
+    - acss redirect stub (`git-subdir` sources): version belongs in **plugin.json only**, remove from marketplace entry
+    - Phase 1's commit currently has versions in both — non-breaking but violates the docs. Phase 2/3 edits must correct this.
 
 ### Phase 1 — Prepare plugin files for extraction (in `/home/user/acss` on branch `claude/move-marketplace-plugins-repo-8kXL9`)
 
@@ -167,6 +229,7 @@ Back in `/home/user/acss` on branch `claude/move-marketplace-plugins-repo-8kXL9`
       }
       ```
       Why `git-subdir` and not `github`: the `github` source type assumes the whole repo is one plugin — no `path` field. `git-subdir` is purpose-built for multi-plugin monorepos and clones sparsely, minimizing bandwidth.
+    - **Remove `version` from each plugin entry** in this redirect stub — per Phase 0 step 3c, non-relative-path sources take version from `plugin.json`, and setting both causes the marketplace entry to be silently ignored.
     - Add a `description` line noting the move: "Plugins now live at shawn-sandy/acss-plugins; this marketplace redirects automatically."
 15. Delete:
     - `/home/user/acss/.claude/plugins/` (entire tree — `rm -rf`)

--- a/docs/planning/we-need-to-move-distributed-porcupine.md
+++ b/docs/planning/we-need-to-move-distributed-porcupine.md
@@ -39,10 +39,13 @@ We also want the new plugin repo to reference the current `shawn-sandy/acss` rep
 - Pre-push checkpoint passed: 91 files, 9 root entries, all source paths rewritten to `./<name>`, all 3 plugin.json manifests intact
 - Scaffolding files added and staged (not yet committed — the commit-signing server in this sandbox rejects commits from `/tmp/` paths): `README.md`, `CONTRIBUTING.md`, `LICENSE`, `.gitignore`, updated `marketplace.json`
 - Current branch in extract: `claude/move-marketplace-plugins-repo-8kXL9` (needs rename to `main`)
+- **Scaffolding files preserved in tree** at `docs/planning/acss-plugins-scaffolding/` so the user can re-run extraction on their own laptop without losing the prepared content. See `docs/planning/acss-plugins-scaffolding/HANDOFF.md` for the step-by-step laptop workflow.
 
 ### Handoff: to finish Phase 2
 
-Run these on a machine where commit signing works (the user's laptop or a CI environment that shares this sandbox's signing identity):
+**Recommended path** — re-run the extraction on the user's laptop using the deterministic commands and scaffolding files stored in `docs/planning/acss-plugins-scaffolding/`. Full instructions in `docs/planning/acss-plugins-scaffolding/HANDOFF.md`. This works regardless of sandbox lifecycle.
+
+**Sandbox-resident path** (only valid while `/tmp/acss-plugins-extract` survives) — run these on a machine where commit signing works:
 
 ```bash
 # 1. Create the remote repo at github.com/shawn-sandy/acss-plugins (empty, no README/LICENSE)

--- a/docs/planning/we-need-to-move-distributed-porcupine.md
+++ b/docs/planning/we-need-to-move-distributed-porcupine.md
@@ -1,0 +1,263 @@
+# Plan: Move Marketplace and Plugins to a New Repository
+
+## Context
+
+Claude Code plugin marketplaces are distributed by cloning the repo they live in. Today, any user running `/plugin marketplace add shawn-sandy/acss` pulls down the entire fpkit library — roughly **14 MB and 911 files** — just to get ~86 plugin files (~573 KB). The npm package `@fpkit/acss` is already clean (`packages/fpkit/package.json` "files" field excludes `.claude/`), so this is strictly about the **git-based marketplace install footprint**, not npm.
+
+We also want the new plugin repo to reference the current `shawn-sandy/acss` repo for ongoing plugin development — e.g., `acss-kit-builder` generates components that must match live fpkit patterns, so plugin authors need access to the real source during development.
+
+**Outcome targets**
+- Fresh marketplace install drops from ~14 MB → ~600 KB
+- Plugin development continues with clear cross-repo conventions
+- No existing user breaks on their next `/plugin marketplace update`
+
+## Decisions (confirmed with user)
+
+| Decision | Choice |
+|---|---|
+| New repo name | `shawn-sandy/acss-plugins` |
+| Layout | Option A — plugins at repo root |
+| Git history | Preserve via `git filter-repo` |
+| Backward compatibility | Transparent redirect (rewrite `acss` marketplace.json to point at new repo) |
+| Bidirectional reference | Full GitHub URLs in plugin docs (no sibling-clone dependency) |
+| Cleanup scope | Delete `.claude/plugins/` and root stale zips only; keep standalone skill, `downloads/`, and historical planning docs |
+
+## Stress-test findings (incorporated into plan below)
+
+Gaps and assumptions caught during review; each maps to a concrete plan change:
+
+| # | Finding | Where it's addressed |
+|---|---|---|
+| 1 | "Sibling-clone" wasn't an existing convention — no script does this | **Round 2 resolution**: dropped the sibling-clone prescription. All fpkit references in plugin docs are rewritten to full GitHub URLs (Phase 1 step 6a), removing any runtime dependency on a local fpkit checkout. CONTRIBUTING.md documents *how* references work, not a required workflow |
+| 2 | SKILL.md files reference `packages/fpkit/src/...` which won't exist in new repo | New Phase 1 step 6a: rewrite repo-relative paths to full `github.com/shawn-sandy/acss/...` URLs before extraction |
+| 3 | `README.md` has no existing plugin section | Phase 3 step 16: *add* a plugins section (not "update if present") |
+| 4 | `git filter-repo` drops root `.gitignore` | Phase 2 step 12a: recreate `.gitignore` explicitly |
+| 5 | Marketplace name collision (`"name": "acss-plugins"` in both repos) is unverified | Phase 0 step 3a: verify Claude Code keys marketplaces by repo slug, not `name` field |
+| 6 | Double-subscription UX unspecified | Phase 0 step 3a test also covers this |
+| 7 | Git-URL `source` object form schema support unverified — linchpin risk | Phase 0 step 3b: fetch and check the marketplace schema; if unsupported, switch to hard-cutover fallback before Phase 1 begins |
+| 8 | No pre-push verification in Phase 2 | Phase 2 step 12b: file-count check and spot-check before `git push` |
+| 9 | Plugin-level `plugin.json` versions not bumped → `/plugin update` may no-op | Phase 1 step 7a: bump each `plugin.json` patch version |
+| 10 | Openspec not used for discoverability | Out of scope — plan-mode scaffold directs to `docs/planning/`; noted for post-merge follow-up |
+| **Second round** | | |
+| 11 | `find . -type f \| wc -l` in Phase 2 verification would count `.git/` internals (thousands) — false safety | Fixed in step 12b: now uses `-not -path './.git/*'` |
+| 12 | Phase 4 never tested the "existing subscriber" scenario — the exact population the redirect serves | Fixed in step 20: split into Scenario A (fresh) and Scenario B (existing subscriber) |
+| 13 | `source` object JSON shape was committed to speculatively before Phase 0 step 3b verifies the schema | Fixed in step 14: illustrative example marked TBD pending schema verification |
+| 14 | CLAUDE.md edit landed in a section where there's nothing to update | Fixed in step 16: new `## Plugins` section between Plans and Publishing |
+| 15 | Internal contradiction — hardened plan prescribed both URL rewrites and sibling-clone convention | Fixed: dropped sibling-clone; CONTRIBUTING.md now describes the URL-based reference scheme only |
+| 16 | CC version compatibility of git-URL `source` objects unexamined | Added to Risks table; Phase 0 step 3b now also captures the minimum CC version |
+| 17 | `marketplace.json.version` bump assumed to force re-clone; actually may be cosmetic | Added to Risks table; plan relies on plugin-level version bumps for re-fetch, not marketplace version |
+| 18 | `validate_css_vars.py` duplication across plugins preserved by migration | Added to Risks table as out-of-scope follow-up |
+| 19 | Users who never run `/plugin marketplace update` stay on stale cache | Added to Risks table as accepted; README post-migration note suggests running update once |
+
+## Scope
+
+### What gets moved to `shawn-sandy/acss-plugins`
+- `/home/user/acss/.claude-plugin/marketplace.json` (then path-rewritten)
+- `/home/user/acss/.claude/plugins/acss-app-builder/` (48 files)
+- `/home/user/acss/.claude/plugins/acss-kit-builder/` (25 files)
+- `/home/user/acss/.claude/plugins/fpkit-developer/` (13 files, still in deprecation window)
+
+### What stays in `shawn-sandy/acss`
+- A **redirect** `.claude-plugin/marketplace.json` (same plugin names, git-URL `source` fields pointing at `shawn-sandy/acss-plugins`)
+- `.claude/skills/fpkit-developer/` — separate standalone project-local skill (11 files)
+- `downloads/fpkit-developer/` — historical release zips
+- All `docs/planning/` historical plugin docs (unchanged)
+
+### What gets deleted
+- `/home/user/acss/.claude/plugins/` (entire directory after migration)
+- `/home/user/acss/fpkit-developer.zip` (~50 KB, stale at root)
+- `/home/user/acss/fpkit-component-builder.zip` (~127 KB, stale at root)
+
+## Target repo layout
+
+```
+acss-plugins/
+├── .claude-plugin/marketplace.json    # paths rewritten: ./acss-app-builder, etc.
+├── acss-app-builder/
+├── acss-kit-builder/
+├── fpkit-developer/                    # removed after one release cycle
+├── README.md                           # overview + link back to shawn-sandy/acss
+├── CONTRIBUTING.md                     # sibling-clone dev workflow
+├── LICENSE                             # MIT, matches existing plugin manifests
+└── .gitignore
+```
+
+## Execution order
+
+### Phase 0 — User prerequisites (manual)
+
+**User must do these before the implementation starts** — GitHub MCP tools here are scoped to `shawn-sandy/acss` and cannot create repos in other namespaces:
+
+1. Create empty repo `github.com/shawn-sandy/acss-plugins` (no README, no license — keep history clean for import).
+2. Install `git-filter-repo`: `pip install git-filter-repo`.
+3. Confirm working tree clean: `git status` in `/home/user/acss`.
+3a. **Marketplace keying + double-subscribe smoke test** (resolves stress-test findings #5, #6): in a disposable Claude Code session, `/plugin marketplace add shawn-sandy/acss`, then manually add a second marketplace with the same internal `name` field (e.g., a temporary fork) and run `/plugin marketplace list`. Confirm Claude Code keys by repo slug, not `name`. If it keys by `name`, abandon the transparent-redirect strategy and fall back to hard cutover.
+3b. **Marketplace schema verification** (resolves stress-test finding #7): fetch `https://anthropic.com/claude-code/marketplace.schema.json`. Confirm the `plugins[].source` field accepts an object form `{ "source": "github", "repo": "...", "path": "..." }`. If it only accepts relative strings, halt: the transparent-redirect strategy is unworkable and must be replaced with hard cutover before any Phase 1 work begins.
+
+### Phase 1 — Prepare plugin files for extraction (in `/home/user/acss` on branch `claude/move-marketplace-plugins-repo-8kXL9`)
+
+4. Edit `/home/user/acss/.claude/plugins/fpkit-developer/README.md`:
+   - Lines 49–50: change `shawn-sandy/acss` → `shawn-sandy/acss-plugins`
+   - Lines 56, 64, 70: change marketplace suffix `@shawn-sandy-acss` → `@shawn-sandy-acss-plugins`
+   - Lines 79–94: rewrite manual-clone instructions to clone `acss-plugins` instead of `acss`
+5. Edit `/home/user/acss/.claude/plugins/acss-kit-builder/README.md` (lines 26–31): rewrite "lives at `.claude/plugins/acss-kit-builder/` in this repository" for standalone-repo context.
+6. Edit `/home/user/acss/.claude/plugins/acss-app-builder/README.md`: spot-check the `../acss-kit-builder/` relative link on line 8 — still resolves under Option A layout, no change needed.
+6a. **Rewrite repo-relative fpkit references in SKILL.md files** (resolves stress-test findings #1, #2) so they remain clickable and accurate from the new repo:
+    - `/home/user/acss/.claude/plugins/acss-app-builder/skills/acss-app-builder/SKILL.md` lines 94, 209: replace `packages/fpkit/src/index.ts` with `https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts`
+    - `/home/user/acss/.claude/plugins/acss-app-builder/skills/acss-app-builder/references/component-source.md` line 42: same treatment
+    - `/home/user/acss/.claude/plugins/acss-app-builder/skills/acss-app-builder/references/forms.md` line 5: rewrite `packages/fpkit/src/components/form/fields.tsx` to full GitHub URL
+    - `/home/user/acss/.claude/plugins/acss-app-builder/assets/forms/field-renderers.tsx` line 6 (comment): same
+    - Sweep all `skills/**/*.md` files in all three plugins for further `packages/fpkit/` mentions and rewrite to full URLs
+7. Edit `/home/user/acss/.claude-plugin/marketplace.json`: add all three plugins to the `plugins` array (currently only `fpkit-developer`). This pre-extract state becomes the seed for the new repo's manifest.
+7a. **Bump individual plugin versions in plugin.json ONLY** (resolves stress-test finding #9) so `/plugin update` detects a change after the redirect lands.
+    - `/home/user/acss/.claude/plugins/fpkit-developer/.claude-plugin/plugin.json`: 0.1.6 → 0.1.7
+    - `/home/user/acss/.claude/plugins/acss-kit-builder/.claude-plugin/plugin.json`: 0.1.0 → 0.1.1
+    - `/home/user/acss/.claude/plugins/acss-app-builder/.claude-plugin/plugin.json`: 0.1.0 → 0.1.1
+    - **Do NOT mirror version into `marketplace.json` entries.** The Claude Code docs warn: *"The plugin manifest always wins silently. For relative-path plugins, set the version in the marketplace entry. For all other plugin sources, set it in the plugin manifest."* Since the redirect uses `git-subdir` (not relative paths), plugin.json is the authoritative source. Also remove the stale `"version": "0.1.6"` that currently sits inside the `fpkit-developer` marketplace entry when rewriting marketplace.json in step 7 — it's the dual-version anti-pattern the docs flag.
+8. Commit: `chore(plugins): prepare READMEs, paths, and manifests for extraction`.
+
+### Phase 2 — Extract plugins into the new repo
+
+9. Clone a mirror to a temp location (never filter-repo the working clone):
+   ```bash
+   git clone --no-local /home/user/acss /tmp/acss-plugins-extract
+   cd /tmp/acss-plugins-extract
+   ```
+10. Run `git filter-repo` with paths and renames:
+    ```bash
+    git filter-repo \
+      --path .claude-plugin/ \
+      --path .claude/plugins/acss-app-builder/ \
+      --path .claude/plugins/acss-kit-builder/ \
+      --path .claude/plugins/fpkit-developer/ \
+      --path-rename .claude/plugins/acss-app-builder/:acss-app-builder/ \
+      --path-rename .claude/plugins/acss-kit-builder/:acss-kit-builder/ \
+      --path-rename .claude/plugins/fpkit-developer/:fpkit-developer/
+    ```
+11. Edit `.claude-plugin/marketplace.json` in the extracted repo: change each plugin's `source` from `./.claude/plugins/<name>` to `./<name>`. Bump version to `0.2.0`.
+12. Add new top-level files:
+    - `README.md` — short overview, install instructions, link to `shawn-sandy/acss` for ongoing fpkit development
+    - `CONTRIBUTING.md` — short doc explaining that fpkit source references in plugin skills use full GitHub URLs pointing at `shawn-sandy/acss`. No sibling clone is required to follow them. If a contributor wants a local fpkit checkout for deep development, they can clone `shawn-sandy/acss` anywhere (sibling is one convenient choice, not a requirement).
+    - `LICENSE` — MIT, matching existing plugin manifests
+12a. **Recreate `.gitignore`** (resolves stress-test finding #4, since `git filter-repo` dropped the original): `node_modules/`, `.DS_Store`, `*.log`, `.env*`
+12b. **Pre-push verification checkpoint** (resolves stress-test finding #8): before pushing, in `/tmp/acss-plugins-extract`:
+    - `find . -type f -not -path './.git/*' | wc -l` → expect ~90 files (86 plugin files + ~4 new top-level files). Halt and investigate if the count differs by more than 5. (The `-not -path './.git/*'` filter is essential — without it, the count includes thousands of git internals and the check is meaningless.)
+    - `ls` at repo root → expect exactly: `.claude-plugin/`, `acss-app-builder/`, `acss-kit-builder/`, `fpkit-developer/`, `README.md`, `CONTRIBUTING.md`, `LICENSE`, `.gitignore`, `.git/`. Any leftover directories (e.g., a stray `.claude/`) mean `git filter-repo` missed a rename.
+    - `cat .claude-plugin/marketplace.json` → confirm all three plugins present and each `source` starts with `./` (not `./.claude/plugins/`).
+    - Spot-check one plugin manifest: `cat acss-app-builder/.claude-plugin/plugin.json` → confirm intact JSON with the bumped version from Phase 1 step 7a.
+13. Set remote and push:
+    ```bash
+    git remote add origin https://github.com/shawn-sandy/acss-plugins.git
+    git push -u origin main
+    ```
+
+### Phase 3 — Rewrite the acss repo as a redirect stub
+
+Back in `/home/user/acss` on branch `claude/move-marketplace-plugins-repo-8kXL9`:
+
+14. Rewrite `/home/user/acss/.claude-plugin/marketplace.json`:
+    - Keep `name: "acss-plugins"`, bump `version` to `0.2.0`
+    - Keep all three plugin entries
+    - Change each `source` from relative path → `git-subdir` object form (**verified against https://code.claude.com/docs/en/plugin-marketplaces**):
+      ```json
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/shawn-sandy/acss-plugins.git",
+        "path": "acss-app-builder"
+      }
+      ```
+      Why `git-subdir` and not `github`: the `github` source type assumes the whole repo is one plugin — no `path` field. `git-subdir` is purpose-built for multi-plugin monorepos and clones sparsely, minimizing bandwidth.
+    - Add a `description` line noting the move: "Plugins now live at shawn-sandy/acss-plugins; this marketplace redirects automatically."
+15. Delete:
+    - `/home/user/acss/.claude/plugins/` (entire tree — `rm -rf`)
+    - `/home/user/acss/fpkit-developer.zip`
+    - `/home/user/acss/fpkit-component-builder.zip`
+16. Update cross-references:
+    - `/home/user/acss/docs/acss-kit-builder-tutorial.md` — rewrite any `.claude/plugins/acss-kit-builder/` paths to `github.com/shawn-sandy/acss-plugins/tree/main/acss-kit-builder/`
+    - `/home/user/acss/openspec/plans/acss-kit-builder-skill.md` — same treatment
+    - `/home/user/acss/packages/fpkit/src/docs/fpkit-developer.mdx` (if present) — update install instructions
+    - `/home/user/acss/README.md` — *add* a new "Claude Code plugins" section below the "Design system" section (README currently has no plugin mention at all; resolves stress-test finding #3). One paragraph: name the three plugins, point to `shawn-sandy/acss-plugins`.
+    - `/home/user/acss/CLAUDE.md` — add a new short section (heading `## Plugins`) between "Plans" and "Publishing", since the existing Project Structure tree does not list `.claude/plugins/` and the Plans section is about planning docs. Content: one paragraph naming `shawn-sandy/acss-plugins` as the new home, note that the marketplace here now redirects, and list the three plugin names.
+17. Commit: `refactor(plugins): extract to shawn-sandy/acss-plugins with redirect stub`.
+18. Push branch: `git push -u origin claude/move-marketplace-plugins-repo-8kXL9`.
+
+### Phase 4 — Verification
+
+19. **Marketplace install works from new repo**, in a fresh Claude Code session:
+    ```
+    /plugin marketplace add shawn-sandy/acss-plugins
+    /plugin install acss-app-builder@shawn-sandy-acss-plugins
+    ```
+    Confirm `/app-init` slash command appears.
+20. **Redirect stub works from old repo** (two scenarios — the second is the one that matters most):
+    - **Scenario A — fresh subscriber**: In a clean session, run `/plugin marketplace add shawn-sandy/acss` then `/plugin install fpkit-developer@shawn-sandy-acss`. Confirm `/fpkit-developer:fpkit-dev` appears and plugin files match new-repo content (spot-check a file's size or checksum).
+    - **Scenario B — existing subscriber (critical)**: Simulate a user who already had `shawn-sandy/acss` subscribed *before* the migration. Easiest reproduction: check out the branch point *before* Phase 3, subscribe (`/plugin marketplace add shawn-sandy/acss`), then check out the migrated state and run only `/plugin marketplace update shawn-sandy-acss`. No `remove` + re-`add`. Confirm the update succeeds, the local cache shrinks to ~600 KB, and `/plugin install fpkit-developer@shawn-sandy-acss` still resolves. This is the scenario the entire redirect strategy exists to serve.
+21. **acss main repo unaffected**:
+    ```
+    npm install && npm run lint
+    npm run build --workspace=@fpkit/acss
+    npm start                              # storybook still opens on :6006
+    ```
+22. **Plugin dev flow works**:
+    - Clone both repos as siblings: `~/work/acss` and `~/work/acss-plugins`
+    - From `~/work/acss-plugins`, confirm any plugin validation script can resolve `../acss/packages/fpkit/src/index.ts`
+23. **Install footprint measurement** (the core outcome target):
+    ```bash
+    du -sh ~/.config/claude/marketplaces/shawn-sandy-acss-plugins/
+    ```
+    Expected: ~600 KB (vs. previous ~14 MB for `shawn-sandy/acss`).
+
+### Phase 5 — Post-release followup (separate change, after one release cycle)
+
+24. Delete `/home/user/acss/.claude-plugin/marketplace.json` and the now-empty `.claude-plugin/` directory.
+25. Remove `fpkit-developer` from `acss-plugins/.claude-plugin/marketplace.json` once its deprecation window closes.
+
+## Critical files
+
+### Must be edited in `/home/user/acss` (this branch)
+- `/home/user/acss/.claude/plugins/fpkit-developer/README.md` — install-instruction rewrite (Phase 1)
+- `/home/user/acss/.claude/plugins/acss-kit-builder/README.md` — standalone-repo context (Phase 1)
+- `/home/user/acss/.claude-plugin/marketplace.json` — twice: Phase 1 (add all plugins) and Phase 3 (convert to redirect)
+- `/home/user/acss/docs/acss-kit-builder-tutorial.md` — path rewrites (Phase 3)
+- `/home/user/acss/openspec/plans/acss-kit-builder-skill.md` — path rewrites (Phase 3)
+- `/home/user/acss/README.md` — plugin link update (Phase 3)
+- `/home/user/acss/CLAUDE.md` — marker note under Plans (Phase 3)
+
+### Must be created in new repo
+- `acss-plugins/README.md` (new)
+- `acss-plugins/CONTRIBUTING.md` (new — sibling-clone workflow doc)
+- `acss-plugins/LICENSE` (new — MIT)
+- `acss-plugins/.gitignore` (new)
+
+### Existing utilities/conventions to reuse
+- **Marketplace schema**: `https://anthropic.com/claude-code/marketplace.schema.json` (already referenced in current `marketplace.json`)
+- **Existing plugin manifests** at `.claude/plugins/*/.claude-plugin/plugin.json` — these need no changes; they get carried into the new repo by `git filter-repo` as-is
+- **CLAUDE.md Plans convention** — plans live in `.claude/plans/` or `openspec/plans/`; this plan lives in `docs/planning/` per the plan-mode scaffold
+- **Branch convention**: all work on `claude/move-marketplace-plugins-repo-8kXL9`; push with `git push -u origin <branch>`
+
+## Risks and mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `git filter-repo` not installed | Low | Phase 0 step 2 calls it out; fallback is clean copy with no history |
+| **Marketplace schema doesn't accept git-URL `source` objects** (stress-test #7) | **High — blocks redirect strategy** | Phase 0 step 3b verifies the schema up front; if unsupported, halt and switch to hard cutover *before* any other work |
+| Marketplace keying by `name` field could cause old+new to collide (stress-test #5) | Medium | Phase 0 step 3a smoke-tests this in a disposable Claude Code session |
+| Double-subscribed users see duplicate plugins (stress-test #6) | Low | Same smoke test resolves it; README note instructs users to `/plugin marketplace remove shawn-sandy-acss` if they see duplicates |
+| `git filter-repo` drops root `.gitignore` (stress-test #4) | Low | Phase 2 step 12a explicitly recreates it |
+| SKILL.md files reference paths that don't exist in new repo (stress-test #2) | Medium — silent breakage for plugin authors browsing the new repo | Phase 1 step 6a rewrites to full GitHub URLs |
+| `/plugin update` no-ops after redirect because plugin.json versions unchanged (stress-test #9) | Medium | Phase 1 step 7a bumps each plugin's patch version |
+| Typo in `git filter-repo --path-rename` ships wrong tree as first commit to remote (stress-test #8) | Medium | Phase 2 step 12b adds file-count + spot-check gate before `git push` |
+| Existing users on old marketplace see stale plugin files cached | Low | `/plugin marketplace update` re-fetches; marketplace.json version bump to `0.2.0` plus individual plugin version bumps force this |
+| Relative cross-link `../acss-kit-builder/` in acss-app-builder README breaks | Low | Option A preserves sibling layout, so this link still resolves |
+| User accidentally publishes to the wrong remote | Low | Phase 2 uses an explicit `/tmp/` clone; the working clone at `/home/user/acss` is never filter-repo'd |
+| Git-URL `source` objects may be gated on a recent Claude Code version | Medium | During Phase 0 step 3b, note which CC version introduced this schema form. If it's newer than the acss-app-builder `claudeCodeMinVersion: 1.0.33`, add the newer minimum to the redirect `marketplace.json` and mention the bump in the new README so users on older CC know to upgrade |
+| `marketplace.json.version` bump (0.1.6 → 0.2.0) may be cosmetic rather than cache-invalidating | Low | The *plugin-level* version bumps in step 7a are doing the real re-fetch work. The marketplace version bump is documentation; do not rely on it to force client updates |
+| `validate_css_vars.py` is duplicated across `fpkit-developer` and `acss-app-builder` and the duplication carries into the new repo | Low — out of scope | Flag as a follow-up; consolidating into a shared location would further reduce install footprint but is orthogonal to this migration |
+| User never runs `/plugin marketplace update` after migration → stays on stale local cache indefinitely | Low | Acceptable: Claude Code only reads remote state on explicit update. The README in `shawn-sandy/acss` should suggest running `/plugin marketplace update shawn-sandy-acss` once post-migration |
+
+## Out of scope (for a later PR)
+
+- Deleting the standalone skill at `/home/user/acss/.claude/skills/fpkit-developer/` — kept for project-local use
+- Cleaning out `/home/user/acss/downloads/fpkit-developer/` historical release zips — move to GitHub Releases separately
+- Removing the redirect stub from `acss` — scheduled for Phase 5 (next release cycle)
+- Updating historical `docs/planning/*.md` docs that mention plugins — left as historical record


### PR DESCRIPTION
Design and stress-test plan for extracting .claude/plugins/ and the
marketplace manifest into a new shawn-sandy/acss-plugins repo. Preserves
history via git filter-repo and uses a transparent-redirect stub in
shawn-sandy/acss so existing marketplace subscribers don't break.

Outcome target: fresh marketplace install drops from ~14 MB to ~600 KB.